### PR TITLE
feat(proxy): use proxyTargetFromRequestUrl for URL parsing in proxy h…

### DIFF
--- a/src/client/src/DevDebugBar.tsx
+++ b/src/client/src/DevDebugBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { DEV_HTTP_API_PREFIX } from "@devHttpApiPrefix";
+import { DEV_HTTP_API_PREFIX } from "@server/routes";
 import { useAppState } from "./AppStateContext";
 import { isViteDev } from "./devDebugBarEnv";
 import "./DevDebugBar.css";

--- a/src/client/src/LeftPanel.tsx
+++ b/src/client/src/LeftPanel.tsx
@@ -6,6 +6,7 @@ import { countries, generes } from "./consts";
 import { CountrySelector } from "./CountrySelector";
 import { fetchCountryFromIp } from "./countryGeo";
 import { SimpleWaitDots } from "./SimpleWaitDots";
+import { HTTP_API_PATHS } from "@server/routes";
 import { WaitCue } from "./WaitCue";
 
 const COUNTRY_STORAGE_KEY = "letterboxd-justwatch-country";
@@ -112,9 +113,12 @@ export function LeftPanel(): React.ReactElement {
     const ac = new AbortController();
     setSuggestionsLoading(true);
     const query = encodeURIComponent(debouncedTitle.trim());
-    fetch(`/api/proxy/https://api.themoviedb.org/3/search/movie?query=${query}`, {
-      signal: ac.signal,
-    })
+    fetch(
+      `${HTTP_API_PATHS.proxyPrefix}/https://api.themoviedb.org/3/search/movie?query=${query}`,
+      {
+        signal: ac.signal,
+      },
+    )
       .then((res) => res.json())
       .then((data: { results?: TMDBMovie[] }) => {
         const results = (data.results || []).slice(0, TMDB_MAX_SUGGESTIONS);

--- a/src/client/src/__tests__/alternativeSearchSubdl.test.ts
+++ b/src/client/src/__tests__/alternativeSearchSubdl.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HTTP_API_PATHS } from "@server/routes";
 import { searchSubs } from "../alternativeSearch";
 
 vi.mock("../showError", () => ({
@@ -44,7 +45,7 @@ describe("searchSubs", () => {
       );
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      "/api/subdl-search",
+      HTTP_API_PATHS.subdlSearch,
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({ title: "Inception", year: 2010 }),

--- a/src/client/src/alternativeSearch.ts
+++ b/src/client/src/alternativeSearch.ts
@@ -3,6 +3,7 @@ import { showMessage } from "./showMessage";
 import { showError } from "./showError";
 import { NOTICE_HOLD_ALT_SEARCH_MS } from "./animation/timing";
 import { captureFrontendException, captureFrontendMessage } from "./sentry";
+import { HTTP_API_PATHS } from "@server/routes";
 import { HTTP_STATUS_INTERNAL_SERVER_ERROR } from "@server/httpStatusCodes";
 
 let isAlternativeSearchInFlight = false;
@@ -20,7 +21,7 @@ export function runAlternativeSearch(
   isAlternativeSearchInFlight = true;
   options?.setAlternativeSearchLoading?.(true);
   toggleNotice(`Searching for ${title} (${year})...`);
-  fetch("/api/alternative-search", {
+  fetch(HTTP_API_PATHS.alternativeSearch, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ title, year }),
@@ -28,7 +29,7 @@ export function runAlternativeSearch(
     .then((res) => {
       if (res.status >= HTTP_STATUS_INTERNAL_SERVER_ERROR) {
         captureFrontendMessage("alternative-search upstream error", {
-          tags: { source: "api", endpoint: "/api/alternative-search", reason: "http-5xx" },
+          tags: { source: "api", endpoint: HTTP_API_PATHS.alternativeSearch, reason: "http-5xx" },
           extra: { status: res.status, title, year },
         });
       }
@@ -43,7 +44,7 @@ export function runAlternativeSearch(
     })
     .catch((err) => {
       captureFrontendException(err, {
-        tags: { source: "api", endpoint: "/api/alternative-search" },
+        tags: { source: "api", endpoint: HTTP_API_PATHS.alternativeSearch },
         extra: { title, year },
       });
       console.error(err);
@@ -56,7 +57,7 @@ export function runAlternativeSearch(
 
 export function searchSubs(query: string, year?: string | number): void {
   if (!query) return;
-  fetch("/api/subdl-search", {
+  fetch(HTTP_API_PATHS.subdlSearch, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ title: query, year }),
@@ -71,7 +72,7 @@ export function searchSubs(query: string, year?: string | number): void {
     })
     .catch((err) => {
       captureFrontendException(err, {
-        tags: { source: "api", endpoint: "/api/subdl-search" },
+        tags: { source: "api", endpoint: HTTP_API_PATHS.subdlSearch },
         extra: { query, year },
       });
       console.error(err);

--- a/src/client/src/main.tsx
+++ b/src/client/src/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { useEffect } from "react";
 import { PostHogProvider, usePostHog } from "@posthog/react";
 import { App } from "./App";
+import { HTTP_API_PATHS } from "@server/routes";
 import { captureFrontendException, initFrontendSentry } from "./sentry";
 
 function PostHogWindowRef(): null {
@@ -33,11 +34,11 @@ if (rootEl) {
       });
     }
     if (params.get("sentryDummyBe") === "1") {
-      fetch("/api/sentry-test?mode=throw")
+      fetch(`${HTTP_API_PATHS.sentryTest}?mode=throw`)
         .then(() => {})
         .catch((err: unknown) => {
           captureFrontendException(err, {
-            tags: { source: "dummy", layer: "frontend", endpoint: "/api/sentry-test" },
+            tags: { source: "dummy", layer: "frontend", endpoint: HTTP_API_PATHS.sentryTest },
           });
         });
     }

--- a/src/client/src/useLetterboxdList.ts
+++ b/src/client/src/useLetterboxdList.ts
@@ -12,6 +12,7 @@ import {
   type MergeData,
   type TileData,
 } from "./movieTiles";
+import { HTTP_API_PATHS } from "@server/routes";
 import { captureFrontendException } from "./sentry";
 import { safeJsonResponse } from "./safeJsonResponse";
 
@@ -159,7 +160,7 @@ export function useLetterboxdList(
           const { title, year } = element;
           const movieData = { title, year, country: data.country ?? "" };
           return () =>
-            fetch("/api/search-movie", {
+            fetch(HTTP_API_PATHS.searchMovie, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(movieData),
@@ -202,7 +203,7 @@ export function useLetterboxdList(
                   }
                 }
                 captureFrontendException(e, {
-                  tags: { source: "api", endpoint: "/api/search-movie", flow: "list-batch" },
+                  tags: { source: "api", endpoint: HTTP_API_PATHS.searchMovie, flow: "list-batch" },
                   extra: { title, year, country: data.country, listUrl: data.listUrl },
                 });
                 console.error(e);
@@ -266,7 +267,7 @@ export function useLetterboxdList(
   const loadWatchlist = useCallback(
     async (data: LoadData): Promise<void> => {
       try {
-        const response = await fetch("/api/letterboxd-watchlist", {
+        const response = await fetch(HTTP_API_PATHS.letterboxdWatchlist, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(data),
@@ -277,7 +278,11 @@ export function useLetterboxdList(
       } catch (e) {
         if (isListFetchTimedOut(e)) {
           captureFrontendException(e, {
-            tags: { source: "api", endpoint: "/api/letterboxd-watchlist", reason: "timeout" },
+            tags: {
+              source: "api",
+              endpoint: HTTP_API_PATHS.letterboxdWatchlist,
+              reason: "timeout",
+            },
             extra: { listType: data.listType, listUrl: data.listUrl, page: data.page },
           });
           showError(
@@ -287,7 +292,7 @@ export function useLetterboxdList(
           return;
         }
         captureFrontendException(e, {
-          tags: { source: "api", endpoint: "/api/letterboxd-watchlist" },
+          tags: { source: "api", endpoint: HTTP_API_PATHS.letterboxdWatchlist },
           extra: { listType: data.listType, listUrl: data.listUrl, page: data.page },
         });
         throw e;
@@ -301,7 +306,7 @@ export function useLetterboxdList(
   const loadCustomList = useCallback(
     async (data: LoadData): Promise<void> => {
       try {
-        const response = await fetch("/api/letterboxd-custom-list", {
+        const response = await fetch(HTTP_API_PATHS.letterboxdCustomList, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(data),
@@ -320,7 +325,11 @@ export function useLetterboxdList(
       } catch (e) {
         if (isListFetchTimedOut(e)) {
           captureFrontendException(e, {
-            tags: { source: "api", endpoint: "/api/letterboxd-custom-list", reason: "timeout" },
+            tags: {
+              source: "api",
+              endpoint: HTTP_API_PATHS.letterboxdCustomList,
+              reason: "timeout",
+            },
             extra: { listType: data.listType, listUrl: data.listUrl, page: data.page },
           });
           showError(
@@ -330,7 +339,7 @@ export function useLetterboxdList(
           return;
         }
         captureFrontendException(e, {
-          tags: { source: "api", endpoint: "/api/letterboxd-custom-list" },
+          tags: { source: "api", endpoint: HTTP_API_PATHS.letterboxdCustomList },
           extra: { listType: data.listType, listUrl: data.listUrl, page: data.page },
         });
         throw e;

--- a/src/client/src/useMovieSearch.ts
+++ b/src/client/src/useMovieSearch.ts
@@ -3,6 +3,7 @@ import { showMessage } from "./showMessage";
 import { PLACEHOLDER_POSTER, normalizePosterPath, type MergeData } from "./movieTiles";
 import { captureFrontendException, captureFrontendMessage } from "./sentry";
 import { SafeJsonResponseError, safeJsonResponse } from "./safeJsonResponse";
+import { HTTP_API_PATHS } from "@server/routes";
 import { HTTP_STATUS_INTERNAL_SERVER_ERROR } from "@server/httpStatusCodes";
 
 export interface MovieSearchResponse {
@@ -48,7 +49,7 @@ export function useMovieSearch(
       }
       isInFlightRef.current = true;
       setMovieSearchLoading?.(true);
-      fetch("/api/search-movie", {
+      fetch(HTTP_API_PATHS.searchMovie, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
@@ -57,7 +58,7 @@ export function useMovieSearch(
           setShowAltSearchButton?.(true);
           if (response.status >= HTTP_STATUS_INTERNAL_SERVER_ERROR) {
             captureFrontendMessage("search-movie upstream error", {
-              tags: { source: "api", endpoint: "/api/search-movie", reason: "http-5xx" },
+              tags: { source: "api", endpoint: HTTP_API_PATHS.searchMovie, reason: "http-5xx" },
               extra: { status: response.status, title: data.title, year: data.year },
             });
             console.error(response);
@@ -81,7 +82,7 @@ export function useMovieSearch(
             captureFrontendMessage("search-movie parse failure", {
               tags: {
                 source: "api",
-                endpoint: "/api/search-movie",
+                endpoint: HTTP_API_PATHS.searchMovie,
                 reason: err.kind,
               },
               extra: {
@@ -94,7 +95,7 @@ export function useMovieSearch(
             });
           }
           captureFrontendException(err, {
-            tags: { source: "api", endpoint: "/api/search-movie" },
+            tags: { source: "api", endpoint: HTTP_API_PATHS.searchMovie },
             extra: { title: data.title, year: data.year, country: data.country },
           });
           console.error(err);

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "paths": {
       "@/*": ["./src/*"],
-      "@server/*": ["../server/*"],
-      "@devHttpApiPrefix": ["../devHttpApiPrefix.ts"]
+      "@server/*": ["../server/*"]
     },
     "target": "ES2022",
     "module": "ESNext",

--- a/src/devHttpApiPrefix.ts
+++ b/src/devHttpApiPrefix.ts
@@ -1,4 +1,0 @@
-/**
- * URL prefix for development-only HTTP APIs (Fastify scoped routes + client fetch).
- */
-export const DEV_HTTP_API_PREFIX = "/api/dev" as const;

--- a/src/server/buildIndexHtmlForClient.ts
+++ b/src/server/buildIndexHtmlForClient.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { getCanonicalProviderByNames } from "./lib/loadCanonicalProviders.js";
+import { injectRuntimeConfig } from "./lib/injectRuntimeConfig.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export function buildIndexHtmlForClient(): string | null {
+  const distIndexPath = path.join(__dirname, "..", "client", "dist", "index.html");
+  if (!fs.existsSync(distIndexPath)) return null;
+
+  const posthogKey = process.env.POSTHOG_KEY || "";
+  const posthogHost = process.env.POSTHOG_HOST || "https://us.i.posthog.com";
+  const html = fs.readFileSync(distIndexPath, "utf8");
+  return injectRuntimeConfig(html, posthogKey, posthogHost, getCanonicalProviderByNames(), {
+    dsn: process.env.SENTRY_DSN || "",
+    release: process.env.SENTRY_RELEASE || "",
+    tracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE || "",
+    sendDefaultPii: process.env.SENTRY_SEND_DEFAULT_PII || "",
+    environment: process.env.NODE_ENV || "",
+  });
+}

--- a/src/server/controllers/proxy.ts
+++ b/src/server/controllers/proxy.ts
@@ -1,4 +1,5 @@
 import type { HttpHandler } from "../httpContext.js";
+import { proxyTargetFromRequestUrl } from "../routes.js";
 import axiosHelper from "../lib/axios.js";
 import { getCacheValue, setCacheValue } from "../lib/redis.js";
 import { parseAllowedProxyUrl } from "../lib/apiSchemas.js";
@@ -22,7 +23,7 @@ function postBodyForAxios(body: unknown): unknown {
 }
 
 export const proxy: HttpHandler = async ({ req, res }) => {
-  const url = (req.url || "").replace("/api/proxy/", "");
+  const url = proxyTargetFromRequestUrl(req.url || "");
   const { method } = req;
   try {
     const parsed = parseAllowedProxyUrl(url);

--- a/src/server/createServer.ts
+++ b/src/server/createServer.ts
@@ -1,54 +1,12 @@
-import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
-import fastifyStatic from "@fastify/static";
-import fastifyCookie from "@fastify/cookie";
-import fastifySession from "@fastify/session";
-import fastifyFormbody from "@fastify/formbody";
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
-import {
-  searchMovie,
-  poster,
-  letterboxdWatchlist,
-  letterboxdCustomList,
-  letterboxdPoster,
-  alternativeSearch,
-  subdlSearch,
-  proxy,
-} from "./controllers/index.js";
-import { isHealthy, disconnectRedis, isRedisDisabled } from "./lib/redis.js";
-import { registerDevHttpRoutes } from "./registerDevHttpRoutes.js";
-import {
-  getCanonicalProviderMap,
-  getCanonicalProviderByNames,
-} from "./lib/loadCanonicalProviders.js";
-import { getPosthog, shutdownPosthog } from "./lib/posthog.js";
-import { injectRuntimeConfig } from "./lib/injectRuntimeConfig.js";
-import type { HttpHandler, HttpRequestContext, HttpResponseContext } from "./httpContext.js";
+import Fastify, { type FastifyInstance } from "fastify";
 import * as Sentry from "@sentry/node";
-import {
-  HTTP_STATUS_INTERNAL_SERVER_ERROR,
-  HTTP_STATUS_NOT_FOUND,
-  HTTP_STATUS_OK,
-} from "./httpStatusCodes.js";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-function loadIndexHtmlWithPosthog(): string | null {
-  const distIndexPath = path.join(__dirname, "..", "client", "dist", "index.html");
-  if (!fs.existsSync(distIndexPath)) return null;
-
-  const posthogKey = process.env.POSTHOG_KEY || "";
-  const posthogHost = process.env.POSTHOG_HOST || "https://us.i.posthog.com";
-  const html = fs.readFileSync(distIndexPath, "utf8");
-  return injectRuntimeConfig(html, posthogKey, posthogHost, getCanonicalProviderByNames(), {
-    dsn: process.env.SENTRY_DSN || "",
-    release: process.env.SENTRY_RELEASE || "",
-    tracesSampleRate: process.env.SENTRY_TRACES_SAMPLE_RATE || "",
-    sendDefaultPii: process.env.SENTRY_SEND_DEFAULT_PII || "",
-    environment: process.env.NODE_ENV || "",
-  });
-}
+import { disconnectRedis } from "./lib/redis.js";
+import { getCanonicalProviderMap } from "./lib/loadCanonicalProviders.js";
+import { getPosthog, shutdownPosthog } from "./lib/posthog.js";
+import { createFastifyHttpBinder } from "./fastifyHttpBridge.js";
+import { buildIndexHtmlForClient } from "./buildIndexHtmlForClient.js";
+import { registerFastifyWiring } from "./registerFastifyWiring.js";
+import { HTTP_STATUS_INTERNAL_SERVER_ERROR } from "./httpStatusCodes.js";
 
 export interface StartedServer {
   port: number;
@@ -62,208 +20,67 @@ export interface CreatedServer {
 }
 
 export function createServer(): CreatedServer {
-  {
-    const app: FastifyInstance = Fastify({
-      logger: true,
-    });
+  const app: FastifyInstance = Fastify({
+    logger: true,
+  });
 
-    const canonicalProviderMap = getCanonicalProviderMap();
-    (app as unknown as { locals?: { [key: string]: unknown } }).locals = {
-      canonicalProviderMap,
-    };
+  const canonicalProviderMap = getCanonicalProviderMap();
+  (app as FastifyInstance & { locals?: { [key: string]: unknown } }).locals = {
+    canonicalProviderMap,
+  };
 
-    const makeFastifyHandler =
-      (handler: HttpHandler) =>
-      async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
-        const locals = ((app as unknown as { locals?: { [key: string]: unknown } }).locals ||
-          {}) as { [key: string]: unknown };
+  const binder = createFastifyHttpBinder(app);
+  const cachedIndexHtml = buildIndexHtmlForClient();
+  registerFastifyWiring(app, binder, cachedIndexHtml);
 
-        const reqContext: HttpRequestContext = {
-          body: request.body ?? {},
-          params: (request.params as Record<string, unknown>) ?? {},
-          query: (request.query as Record<string, unknown>) ?? {},
-          headers: (request.headers as Record<string, unknown>) ?? {},
-          method: request.method,
-          url: request.url,
-          cookies: ((request as unknown as { cookies?: Record<string, unknown> }).cookies ??
-            {}) as Record<string, unknown>,
-          session: (request as unknown as { session?: unknown }).session ?? null,
-          appLocals: {
-            canonicalProviderMap: locals.canonicalProviderMap,
-          },
-        };
-
-        const resContext: HttpResponseContext = {
-          status(code: number): HttpResponseContext {
-            reply.code(code);
-            return this;
-          },
-          json(payload: unknown): void {
-            reply.send(payload);
-          },
-          send(payload?: unknown): void {
-            if (payload === undefined) {
-              reply.send();
-            } else {
-              reply.send(payload);
-            }
-          },
-          setHeader(name: string, value: string | number | readonly string[]): HttpResponseContext {
-            reply.header(name, value);
-            return this;
-          },
-        };
-
-        await handler({ req: reqContext, res: resContext });
-      };
-
-    const cachedIndexHtml = loadIndexHtmlWithPosthog();
-
-    app.get("/", async (_request, reply) => {
-      if (!cachedIndexHtml) {
-        reply.code(HTTP_STATUS_NOT_FOUND).send();
-        return;
-      }
-      reply.header("Content-Type", "text/html; charset=utf-8");
-      reply.send(cachedIndexHtml);
-    });
-
-    const publicDistPath = path.join(__dirname, "..", "client", "dist");
-    void app.register(fastifyStatic, {
-      root: publicDistPath,
-      prefix: "/",
-    });
-
-    app.get("/movie_placeholder.svg", async (_request, reply) => {
-      return reply.sendFile("movie_placeholder.svg", path.join(__dirname, "..", "client"));
-    });
-
-    const appSecretKey = process.env.APP_SECRET_KEY;
-    if (!appSecretKey && process.env.NODE_ENV === "production") {
-      throw new Error("APP_SECRET_KEY environment variable must be set in production.");
+  const posthog = getPosthog();
+  app.setErrorHandler(async (err, request, reply) => {
+    console.error(err);
+    if (Sentry.getClient()) {
+      Sentry.captureException(err, {
+        extra: { method: request.method, url: request.url },
+      });
     }
-    /** @fastify/session requires secret length ≥ 32 */
-    const sessionSecret = appSecretKey || "dev-only-session-secret-do-not-use-in-production!!";
-
-    void app.register(fastifyCookie, {
-      secret: sessionSecret,
-    });
-
-    void app.register(fastifySession, {
-      secret: sessionSecret,
-      cookie: {
-        maxAge: 24 * 60 * 60 * 1000,
-        sameSite: "lax",
-        secure: true,
-        httpOnly: true,
-      },
-    });
-
-    void app.register(fastifyFormbody);
-
-    const setCacheControlFastify =
-      (handler: HttpHandler) => async (request: FastifyRequest, reply: FastifyReply) => {
-        reply.header("Cache-Control", "public, max-age=3600");
-        await makeFastifyHandler(handler)(request, reply);
-      };
-
-    app.get("/healthcheck", async (_request, reply) => {
-      reply.type("text/plain").send("OK");
-    });
-
-    app.get("/redis-healthcheck", async (_request, reply) => {
-      if (isRedisDisabled()) {
-        reply.type("text/plain").code(HTTP_STATUS_OK).send("OK (Redis disabled)");
-        return;
-      }
-      if (await isHealthy()) {
-        reply.type("text/plain").code(HTTP_STATUS_OK).send("OK");
-      } else {
-        reply
-          .type("text/plain")
-          .code(HTTP_STATUS_INTERNAL_SERVER_ERROR)
-          .send("Redis is not healthy");
-      }
-    });
-
-    app.post("/api/search-movie", setCacheControlFastify(searchMovie));
-    app.post("/api/poster", setCacheControlFastify(poster));
-    app.post("/api/letterboxd-watchlist", setCacheControlFastify(letterboxdWatchlist));
-    app.post("/api/letterboxd-custom-list", setCacheControlFastify(letterboxdCustomList));
-    app.post("/api/letterboxd-poster", setCacheControlFastify(letterboxdPoster));
-    app.post("/api/alternative-search", setCacheControlFastify(alternativeSearch));
-    app.post("/api/subdl-search", setCacheControlFastify(subdlSearch));
-
-    app.all("/api/proxy/*", makeFastifyHandler(proxy));
-
-    registerDevHttpRoutes(app);
-
-    app.get("/api/sentry-test", async (request, reply) => {
-      const mode = ((request.query as { mode?: string })?.mode ?? "throw").toLowerCase();
-      if (mode === "response") {
-        const err = new Error("Dummy BE Sentry test response error");
-        if (Sentry.getClient()) {
-          Sentry.captureException(err, {
-            extra: { endpoint: "/api/sentry-test", mode, method: request.method, url: request.url },
-          });
-        }
-        reply.code(HTTP_STATUS_INTERNAL_SERVER_ERROR).send({
-          error: "Dummy backend response error for Sentry testing",
-        });
-        return;
-      }
-      throw new Error("Dummy BE Sentry test throw");
-    });
-
-    const posthog = getPosthog();
-    app.setErrorHandler(async (err, request, reply) => {
-      console.error(err);
-      if (Sentry.getClient()) {
-        Sentry.captureException(err, {
-          extra: { method: request.method, url: request.url },
-        });
-      }
-      if (posthog) {
-        try {
-          await posthog.capture({
-            distinctId: "server-error",
-            event: "server_error",
-            properties: {
-              message: (err as Error).message,
-              name: (err as Error).name,
-            },
-          });
-        } catch {
-          // ignore PostHog errors
-        }
-      }
-      if (!reply.raw.headersSent) {
-        reply.code(HTTP_STATUS_INTERNAL_SERVER_ERROR).send({ error: "Internal Server Error" });
-      }
-    });
-
-    return {
-      framework: "fastify",
-      app,
-      async start(portArg?: number): Promise<StartedServer> {
-        const desiredPort = portArg ?? Number(process.env.PORT ?? 3000);
-
-        await app.listen({ port: desiredPort, host: "0.0.0.0" });
-        const address = app.server.address();
-        const actualPort =
-          typeof address === "object" && address && "port" in address
-            ? (address.port as number)
-            : desiredPort;
-
-        return {
-          port: actualPort,
-          async close() {
-            await app.close();
-            await disconnectRedis();
-            await shutdownPosthog();
+    if (posthog) {
+      try {
+        await posthog.capture({
+          distinctId: "server-error",
+          event: "server_error",
+          properties: {
+            message: (err as Error).message,
+            name: (err as Error).name,
           },
-        };
-      },
-    };
-  }
+        });
+      } catch {
+        // ignore PostHog errors
+      }
+    }
+    if (!reply.raw.headersSent) {
+      reply.code(HTTP_STATUS_INTERNAL_SERVER_ERROR).send({ error: "Internal Server Error" });
+    }
+  });
+
+  return {
+    framework: "fastify",
+    app,
+    async start(portArg?: number): Promise<StartedServer> {
+      const desiredPort = portArg ?? Number(process.env.PORT ?? 3000);
+
+      await app.listen({ port: desiredPort, host: "0.0.0.0" });
+      const address = app.server.address();
+      const actualPort =
+        typeof address === "object" && address && "port" in address
+          ? (address.port as number)
+          : desiredPort;
+
+      return {
+        port: actualPort,
+        async close() {
+          await app.close();
+          await disconnectRedis();
+          await shutdownPosthog();
+        },
+      };
+    },
+  };
 }

--- a/src/server/fastifyHttpBridge.ts
+++ b/src/server/fastifyHttpBridge.ts
@@ -1,0 +1,69 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import type { HttpHandler, HttpRequestContext, HttpResponseContext } from "./httpContext.js";
+
+type AppLocals = { canonicalProviderMap?: unknown; [key: string]: unknown };
+
+export type FastifyRouteHandler = (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+export interface FastifyHttpBinder {
+  makeFastifyHandler: (handler: HttpHandler) => FastifyRouteHandler;
+  setCacheControlFastify: (handler: HttpHandler) => FastifyRouteHandler;
+}
+
+function getAppLocals(app: FastifyInstance): AppLocals {
+  return ((app as FastifyInstance & { locals?: AppLocals }).locals ?? {}) as AppLocals;
+}
+
+export function createFastifyHttpBinder(app: FastifyInstance): FastifyHttpBinder {
+  const makeFastifyHandler =
+    (handler: HttpHandler) =>
+    async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+      const locals = getAppLocals(app);
+
+      const reqContext: HttpRequestContext = {
+        body: request.body ?? {},
+        params: (request.params as Record<string, unknown>) ?? {},
+        query: (request.query as Record<string, unknown>) ?? {},
+        headers: (request.headers as Record<string, unknown>) ?? {},
+        method: request.method,
+        url: request.url,
+        cookies: ((request as FastifyRequest & { cookies?: Record<string, unknown> }).cookies ??
+          {}) as Record<string, unknown>,
+        session: (request as FastifyRequest & { session?: unknown }).session ?? null,
+        appLocals: {
+          canonicalProviderMap: locals.canonicalProviderMap,
+        },
+      };
+
+      const resContext: HttpResponseContext = {
+        status(code: number): HttpResponseContext {
+          reply.code(code);
+          return this;
+        },
+        json(payload: unknown): void {
+          reply.send(payload);
+        },
+        send(payload?: unknown): void {
+          if (payload === undefined) {
+            reply.send();
+          } else {
+            reply.send(payload);
+          }
+        },
+        setHeader(name: string, value: string | number | readonly string[]): HttpResponseContext {
+          reply.header(name, value);
+          return this;
+        },
+      };
+
+      await handler({ req: reqContext, res: resContext });
+    };
+
+  const setCacheControlFastify =
+    (handler: HttpHandler) => async (request: FastifyRequest, reply: FastifyReply) => {
+      reply.header("Cache-Control", "public, max-age=3600");
+      await makeFastifyHandler(handler)(request, reply);
+    };
+
+  return { makeFastifyHandler, setCacheControlFastify };
+}

--- a/src/server/registerDevHttpRoutes.ts
+++ b/src/server/registerDevHttpRoutes.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import rateLimit from "@fastify/rate-limit";
 import { exec as execCallback } from "node:child_process";
 import { promisify } from "node:util";
-import { DEV_HTTP_API_PREFIX } from "../devHttpApiPrefix.js";
+import { DEV_HTTP_API_PREFIX } from "./routes.js";
 import { devRedisApisAllowedOrReply, isNodeProductionEnvironment } from "./lib/devApiGuard.js";
 import { clearCacheByCategory } from "./lib/redis.js";
 import { HTTP_STATUS_INTERNAL_SERVER_ERROR } from "./httpStatusCodes.js";

--- a/src/server/registerFastifyAppApi.ts
+++ b/src/server/registerFastifyAppApi.ts
@@ -1,0 +1,45 @@
+import type { FastifyInstance } from "fastify";
+import { HTTP_API_PATHS, HTTP_API_PROXY_ROUTE } from "./routes.js";
+import {
+  searchMovie,
+  poster,
+  letterboxdWatchlist,
+  letterboxdCustomList,
+  letterboxdPoster,
+  alternativeSearch,
+  subdlSearch,
+  proxy,
+} from "./controllers/index.js";
+import { isHealthy, isRedisDisabled } from "./lib/redis.js";
+import type { FastifyHttpBinder } from "./fastifyHttpBridge.js";
+import { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } from "./httpStatusCodes.js";
+
+export function registerFastifyAppApi(app: FastifyInstance, binder: FastifyHttpBinder): void {
+  const { makeFastifyHandler, setCacheControlFastify } = binder;
+
+  app.get("/healthcheck", async (_request, reply) => {
+    reply.type("text/plain").send("OK");
+  });
+
+  app.get("/redis-healthcheck", async (_request, reply) => {
+    if (isRedisDisabled()) {
+      reply.type("text/plain").code(HTTP_STATUS_OK).send("OK (Redis disabled)");
+      return;
+    }
+    if (await isHealthy()) {
+      reply.type("text/plain").code(HTTP_STATUS_OK).send("OK");
+    } else {
+      reply.type("text/plain").code(HTTP_STATUS_INTERNAL_SERVER_ERROR).send("Redis is not healthy");
+    }
+  });
+
+  app.post(HTTP_API_PATHS.searchMovie, setCacheControlFastify(searchMovie));
+  app.post(HTTP_API_PATHS.poster, setCacheControlFastify(poster));
+  app.post(HTTP_API_PATHS.letterboxdWatchlist, setCacheControlFastify(letterboxdWatchlist));
+  app.post(HTTP_API_PATHS.letterboxdCustomList, setCacheControlFastify(letterboxdCustomList));
+  app.post(HTTP_API_PATHS.letterboxdPoster, setCacheControlFastify(letterboxdPoster));
+  app.post(HTTP_API_PATHS.alternativeSearch, setCacheControlFastify(alternativeSearch));
+  app.post(HTTP_API_PATHS.subdlSearch, setCacheControlFastify(subdlSearch));
+
+  app.all(HTTP_API_PROXY_ROUTE, makeFastifyHandler(proxy));
+}

--- a/src/server/registerFastifySentryTestRoute.ts
+++ b/src/server/registerFastifySentryTestRoute.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from "fastify";
+import * as Sentry from "@sentry/node";
+import { HTTP_API_PATHS } from "./routes.js";
+import { HTTP_STATUS_INTERNAL_SERVER_ERROR } from "./httpStatusCodes.js";
+
+export function registerFastifySentryTestRoute(app: FastifyInstance): void {
+  app.get(HTTP_API_PATHS.sentryTest, async (request, reply) => {
+    const mode = ((request.query as { mode?: string })?.mode ?? "throw").toLowerCase();
+    if (mode === "response") {
+      const err = new Error("Dummy BE Sentry test response error");
+      if (Sentry.getClient()) {
+        Sentry.captureException(err, {
+          extra: {
+            endpoint: HTTP_API_PATHS.sentryTest,
+            mode,
+            method: request.method,
+            url: request.url,
+          },
+        });
+      }
+      reply.code(HTTP_STATUS_INTERNAL_SERVER_ERROR).send({
+        error: "Dummy backend response error for Sentry testing",
+      });
+      return;
+    }
+    throw new Error("Dummy BE Sentry test throw");
+  });
+}

--- a/src/server/registerFastifySessionPlugins.ts
+++ b/src/server/registerFastifySessionPlugins.ts
@@ -1,0 +1,29 @@
+import type { FastifyInstance } from "fastify";
+import fastifyCookie from "@fastify/cookie";
+import fastifySession from "@fastify/session";
+import fastifyFormbody from "@fastify/formbody";
+
+export function registerFastifySessionPlugins(app: FastifyInstance): void {
+  const appSecretKey = process.env.APP_SECRET_KEY;
+  if (!appSecretKey && process.env.NODE_ENV === "production") {
+    throw new Error("APP_SECRET_KEY environment variable must be set in production.");
+  }
+  /** @fastify/session requires secret length ≥ 32 */
+  const sessionSecret = appSecretKey || "dev-only-session-secret-do-not-use-in-production!!";
+
+  void app.register(fastifyCookie, {
+    secret: sessionSecret,
+  });
+
+  void app.register(fastifySession, {
+    secret: sessionSecret,
+    cookie: {
+      maxAge: 24 * 60 * 60 * 1000,
+      sameSite: "lax",
+      secure: true,
+      httpOnly: true,
+    },
+  });
+
+  void app.register(fastifyFormbody);
+}

--- a/src/server/registerFastifyStaticAndIndex.ts
+++ b/src/server/registerFastifyStaticAndIndex.ts
@@ -1,0 +1,31 @@
+import type { FastifyInstance } from "fastify";
+import fastifyStatic from "@fastify/static";
+import path from "path";
+import { fileURLToPath } from "url";
+import { HTTP_STATUS_NOT_FOUND } from "./httpStatusCodes.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export function registerFastifyStaticAndIndex(
+  app: FastifyInstance,
+  cachedIndexHtml: string | null,
+): void {
+  app.get("/", async (_request, reply) => {
+    if (!cachedIndexHtml) {
+      reply.code(HTTP_STATUS_NOT_FOUND).send();
+      return;
+    }
+    reply.header("Content-Type", "text/html; charset=utf-8");
+    reply.send(cachedIndexHtml);
+  });
+
+  const publicDistPath = path.join(__dirname, "..", "client", "dist");
+  void app.register(fastifyStatic, {
+    root: publicDistPath,
+    prefix: "/",
+  });
+
+  app.get("/movie_placeholder.svg", async (_request, reply) => {
+    return reply.sendFile("movie_placeholder.svg", path.join(__dirname, "..", "client"));
+  });
+}

--- a/src/server/registerFastifyWiring.ts
+++ b/src/server/registerFastifyWiring.ts
@@ -1,0 +1,19 @@
+import type { FastifyInstance } from "fastify";
+import type { FastifyHttpBinder } from "./fastifyHttpBridge.js";
+import { registerDevHttpRoutes } from "./registerDevHttpRoutes.js";
+import { registerFastifyAppApi } from "./registerFastifyAppApi.js";
+import { registerFastifySentryTestRoute } from "./registerFastifySentryTestRoute.js";
+import { registerFastifySessionPlugins } from "./registerFastifySessionPlugins.js";
+import { registerFastifyStaticAndIndex } from "./registerFastifyStaticAndIndex.js";
+
+export function registerFastifyWiring(
+  app: FastifyInstance,
+  binder: FastifyHttpBinder,
+  cachedIndexHtml: string | null,
+): void {
+  registerFastifyStaticAndIndex(app, cachedIndexHtml);
+  registerFastifySessionPlugins(app);
+  registerFastifyAppApi(app, binder);
+  registerDevHttpRoutes(app);
+  registerFastifySentryTestRoute(app);
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -1,0 +1,28 @@
+/**
+ * HTTP path constants shared by Fastify and the Vite client (`@server/routes`).
+ * Not Fastify registration — only strings and small helpers.
+ */
+
+/** Development-only JSON APIs (`registerDevHttpRoutes` + `DevDebugBar`). */
+export const DEV_HTTP_API_PREFIX = "/api/dev" as const;
+
+/** Production same-origin JSON + proxy endpoints. */
+export const HTTP_API_PATHS = {
+  searchMovie: "/api/search-movie",
+  poster: "/api/poster",
+  letterboxdWatchlist: "/api/letterboxd-watchlist",
+  letterboxdCustomList: "/api/letterboxd-custom-list",
+  letterboxdPoster: "/api/letterboxd-poster",
+  alternativeSearch: "/api/alternative-search",
+  subdlSearch: "/api/subdl-search",
+  proxyPrefix: "/api/proxy",
+  sentryTest: "/api/sentry-test",
+} as const;
+
+/** Fastify `app.all` pattern for the HTTPS proxy (must end with `/*`). */
+export const HTTP_API_PROXY_ROUTE = `${HTTP_API_PATHS.proxyPrefix}/*` as const;
+
+/** Strip our proxy mount from `req.url` to recover the target URL string. */
+export function proxyTargetFromRequestUrl(requestUrl: string): string {
+  return (requestUrl || "").replace(`${HTTP_API_PATHS.proxyPrefix}/`, "");
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -24,5 +24,13 @@ export const HTTP_API_PROXY_ROUTE = `${HTTP_API_PATHS.proxyPrefix}/*` as const;
 
 /** Strip our proxy mount from `req.url` to recover the target URL string. */
 export function proxyTargetFromRequestUrl(requestUrl: string): string {
-  return (requestUrl || "").replace(`${HTTP_API_PATHS.proxyPrefix}/`, "");
+  const normalizedRequestUrl = requestUrl || "";
+  const proxyPrefixWithSlash = `${HTTP_API_PATHS.proxyPrefix}/`;
+  const proxyPrefixIndex = normalizedRequestUrl.indexOf(proxyPrefixWithSlash);
+
+  if (proxyPrefixIndex === -1) {
+    return normalizedRequestUrl;
+  }
+
+  return normalizedRequestUrl.slice(proxyPrefixIndex + proxyPrefixWithSlash.length);
 }

--- a/tests/backend.integration.test.ts
+++ b/tests/backend.integration.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
+import { HTTP_API_PATHS } from "@server/routes";
 import { createServer } from "@server/createServer.js";
 import { _injectRedisClientForTest, _resetRedisForTesting } from "@server/lib/redis.js";
 
@@ -80,10 +81,32 @@ describe("backend integration (fastify)", () => {
     expect(text).toBe("OK");
   });
 
+  it("POST /api/search-movie without title returns JSON and sets cache headers", async () => {
+    const res = await fetch(`${baseUrl}${HTTP_API_PATHS.searchMovie}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.headers.get("cache-control")).toBe("public, max-age=3600");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { message?: string };
+    expect(body).toMatchObject({ message: "Movie not found" });
+  });
+
+  it("GET /api/sentry-test?mode=response returns JSON error without throwing", async () => {
+    const res = await fetch(`${baseUrl}${HTTP_API_PATHS.sentryTest}?mode=response`);
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toContain("Sentry");
+  });
+
   it.skipIf(!process.env.MOVIE_DB_API_KEY)(
     "POST /api/search-movie responds with JSON shape",
     async () => {
-      const res = await fetch(`${baseUrl}/api/search-movie`, {
+      const res = await fetch(`${baseUrl}${HTTP_API_PATHS.searchMovie}`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -105,4 +128,33 @@ describe("backend integration (fastify)", () => {
       expect(typeof (body as { title: unknown }).title).toBe("string");
     },
   );
+});
+
+describe("backend integration (DISABLE_REDIS)", () => {
+  let baseUrl: string;
+  let closeServer: (() => Promise<void>) | null = null;
+
+  beforeAll(async () => {
+    _resetRedisForTesting();
+    vi.stubEnv("DISABLE_REDIS", "1");
+    const created = createServer();
+    const { port, close } = await created.start(0);
+    baseUrl = `http://127.0.0.1:${port}`;
+    closeServer = close;
+  });
+
+  afterAll(async () => {
+    if (closeServer) {
+      await closeServer();
+      closeServer = null;
+    }
+    vi.unstubAllEnvs();
+  });
+
+  it("GET /redis-healthcheck returns OK (Redis disabled)", async () => {
+    const res = await fetch(`${baseUrl}/redis-healthcheck`);
+    const text = await res.text();
+    expect(res.status).toBe(200);
+    expect(text).toBe("OK (Redis disabled)");
+  });
 });

--- a/tests/buildIndexHtmlForClient.test.ts
+++ b/tests/buildIndexHtmlForClient.test.ts
@@ -1,0 +1,31 @@
+import fs from "fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("buildIndexHtmlForClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("returns null when client dist index.html is not on disk", async () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const { buildIndexHtmlForClient } = await import("@server/buildIndexHtmlForClient.js");
+    expect(buildIndexHtmlForClient()).toBeNull();
+  });
+
+  it("reads index.html and passes buffer through injectRuntimeConfig when present", async () => {
+    vi.doMock("@server/lib/injectRuntimeConfig.js", () => ({
+      injectRuntimeConfig: () => "<html>injected</html>",
+    }));
+    vi.doMock("@server/lib/loadCanonicalProviders.js", () => ({
+      getCanonicalProviderByNames: () => ({ providers: [] }),
+    }));
+    vi.resetModules();
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
+    vi.spyOn(fs, "readFileSync").mockReturnValue("<html>raw</html>");
+
+    const { buildIndexHtmlForClient } = await import("@server/buildIndexHtmlForClient.js");
+    expect(buildIndexHtmlForClient()).toBe("<html>injected</html>");
+    expect(fs.readFileSync).toHaveBeenCalled();
+  });
+});

--- a/tests/createServer.test.ts
+++ b/tests/createServer.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as posthogLib from "@server/lib/posthog.js";
+import * as redisLib from "@server/lib/redis.js";
+import { _injectRedisClientForTest, _resetRedisForTesting } from "@server/lib/redis.js";
+
+function createInMemoryRedisMock() {
+  const store = new Map<string, string>();
+  const sets = new Map<string, Set<string>>();
+  return {
+    ping: () => Promise.resolve("PONG"),
+    get: (key: string) => Promise.resolve(store.get(key) ?? null),
+    set: (key: string, value: string) => {
+      store.set(key, value);
+      return Promise.resolve("OK");
+    },
+    del: (...keys: string[]) => {
+      let n = 0;
+      for (const k of keys) {
+        if (store.delete(k)) n++;
+        for (const s of sets.values()) s.delete(k);
+      }
+      return Promise.resolve(n);
+    },
+    sadd: (key: string, ...members: string[]) => {
+      let s = sets.get(key);
+      if (!s) {
+        s = new Set();
+        sets.set(key, s);
+      }
+      let added = 0;
+      for (const m of members) {
+        if (!s.has(m)) {
+          s.add(m);
+          added++;
+        }
+      }
+      return Promise.resolve(added);
+    },
+    smembers: (key: string) => Promise.resolve([...(sets.get(key) ?? [])]),
+    quit: () => Promise.resolve(undefined as void),
+    on: () => {},
+  };
+}
+
+describe("createServer", () => {
+  beforeEach(() => {
+    _injectRedisClientForTest(createInMemoryRedisMock() as never);
+  });
+
+  afterEach(async () => {
+    _resetRedisForTesting();
+    vi.restoreAllMocks();
+  });
+
+  it("error handler returns JSON 500 for uncaught route errors", async () => {
+    const { createServer } = await import("@server/createServer.js");
+    const created = createServer();
+    created.app.get("/__test_throw", async () => {
+      throw new Error("planned failure");
+    });
+    const { port, close } = await created.start(0);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/__test_throw`);
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: "Internal Server Error" });
+    } finally {
+      await close();
+    }
+  });
+
+  it("close calls disconnectRedis and shutdownPosthog", async () => {
+    const disconnectRedis = vi.spyOn(redisLib, "disconnectRedis").mockResolvedValue(undefined);
+    const shutdownPosthog = vi.spyOn(posthogLib, "shutdownPosthog").mockResolvedValue(undefined);
+
+    const { createServer } = await import("@server/createServer.js");
+    const created = createServer();
+    const { close } = await created.start(0);
+    try {
+      await close();
+      expect(disconnectRedis).toHaveBeenCalledTimes(1);
+      expect(shutdownPosthog).toHaveBeenCalledTimes(1);
+    } finally {
+      disconnectRedis.mockRestore();
+      shutdownPosthog.mockRestore();
+    }
+  });
+});

--- a/tests/fastifyHttpBridge.test.ts
+++ b/tests/fastifyHttpBridge.test.ts
@@ -1,0 +1,60 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { describe, it, expect } from "vitest";
+import { createFastifyHttpBinder } from "@server/fastifyHttpBridge.js";
+
+type AppWithLocals = FastifyInstance & { locals?: Record<string, unknown> };
+
+describe("createFastifyHttpBinder", () => {
+  it("maps Fastify request into HttpRequestContext for the handler", async () => {
+    const app = Fastify({ logger: false });
+    (app as AppWithLocals).locals = {
+      canonicalProviderMap: { provider: "test-map" },
+    };
+    const { makeFastifyHandler } = createFastifyHttpBinder(app);
+
+    app.post(
+      "/echo",
+      makeFastifyHandler(async ({ req, res }) => {
+        expect(req.method).toBe("POST");
+        expect(req.url).toMatch(/^\/echo(\?|$)/);
+        expect(req.query).toEqual({ q: "1" });
+        expect(req.body).toEqual({ hello: "world" });
+        expect(req.params).toEqual({});
+        expect(typeof req.headers.host).toBe("string");
+        expect(req.appLocals.canonicalProviderMap).toEqual({ provider: "test-map" });
+        res.status(201).json({ ok: true });
+      }),
+    );
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/echo?q=1",
+      headers: { "content-type": "application/json" },
+      payload: { hello: "world" },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual({ ok: true });
+    await app.close();
+  });
+
+  it("setCacheControlFastify adds Cache-Control before invoking the handler", async () => {
+    const app = Fastify({ logger: false });
+    (app as AppWithLocals).locals = {};
+    const { setCacheControlFastify } = createFastifyHttpBinder(app);
+
+    app.get(
+      "/cached",
+      setCacheControlFastify(async ({ res }) => {
+        res.json({ done: true });
+      }),
+    );
+
+    const res = await app.inject({ method: "GET", url: "/cached" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["cache-control"]).toBe("public, max-age=3600");
+    expect(res.json()).toEqual({ done: true });
+    await app.close();
+  });
+});

--- a/tests/letterboxdListSecurity.test.ts
+++ b/tests/letterboxdListSecurity.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HTTP_API_PATHS } from "@server/routes";
 import type { HttpRequestContext, HttpResponseContext } from "@server/httpContext.js";
 
 const { mockFetchLetterboxdHtml } = vi.hoisted(() => ({
@@ -72,7 +73,7 @@ describe("letterboxd list URL validation (SSRF guard)", () => {
       query: {},
       headers: {},
       method: "POST",
-      url: "/api/letterboxd-watchlist",
+      url: HTTP_API_PATHS.letterboxdWatchlist,
       cookies: {},
       session: null,
       appLocals: {},
@@ -95,7 +96,7 @@ describe("letterboxd list URL validation (SSRF guard)", () => {
       query: {},
       headers: {},
       method: "POST",
-      url: "/api/letterboxd-custom-list",
+      url: HTTP_API_PATHS.letterboxdCustomList,
       cookies: {},
       session: null,
       appLocals: {},
@@ -119,7 +120,7 @@ describe("letterboxd list URL validation (SSRF guard)", () => {
       query: {},
       headers: {},
       method: "POST",
-      url: "/api/letterboxd-custom-list",
+      url: HTTP_API_PATHS.letterboxdCustomList,
       cookies: {},
       session: null,
       appLocals: {},
@@ -142,7 +143,7 @@ describe("letterboxd list URL validation (SSRF guard)", () => {
       query: {},
       headers: {},
       method: "POST",
-      url: "/api/letterboxd-watchlist",
+      url: HTTP_API_PATHS.letterboxdWatchlist,
       cookies: {},
       session: null,
       appLocals: {},

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HTTP_API_PATHS } from "@server/routes";
 import type { HttpRequestContext, HttpResponseContext } from "@server/httpContext.js";
 
 const { mockGet, mockPost, mockGetCache, mockSetCache } = vi.hoisted(() => ({
@@ -104,7 +105,7 @@ describe("proxy handler", () => {
       query: {},
       headers: {},
       method: "GET",
-      url: "/api/proxy/https://malicious.example/hook",
+      url: `${HTTP_API_PATHS.proxyPrefix}/https://malicious.example/hook`,
       cookies: {},
       session: null,
       appLocals: {},
@@ -125,7 +126,7 @@ describe("proxy handler", () => {
       query: {},
       headers: {},
       method: "GET",
-      url: "/api/proxy/https://api.themoviedb.org/3/search/movie?query=test",
+      url: `${HTTP_API_PATHS.proxyPrefix}/https://api.themoviedb.org/3/search/movie?query=test`,
       cookies: {},
       session: null,
       appLocals: {},
@@ -148,7 +149,7 @@ describe("proxy handler", () => {
       query: {},
       headers: {},
       method: "POST",
-      url: "/api/proxy/https://api.themoviedb.org/3/foo",
+      url: `${HTTP_API_PATHS.proxyPrefix}/https://api.themoviedb.org/3/foo`,
       cookies: {},
       session: null,
       appLocals: {},
@@ -168,7 +169,7 @@ describe("proxy handler", () => {
       query: {},
       headers: {},
       method: "POST",
-      url: "/api/proxy/https://api.themoviedb.org/3/foo",
+      url: `${HTTP_API_PATHS.proxyPrefix}/https://api.themoviedb.org/3/foo`,
       cookies: {},
       session: null,
       appLocals: {},
@@ -186,7 +187,7 @@ describe("proxy handler", () => {
       query: {},
       headers: {},
       method: "PUT",
-      url: "/api/proxy/https://api.themoviedb.org/3/foo",
+      url: `${HTTP_API_PATHS.proxyPrefix}/https://api.themoviedb.org/3/foo`,
       cookies: {},
       session: null,
       appLocals: {},

--- a/tests/registerFastifySessionPlugins.test.ts
+++ b/tests/registerFastifySessionPlugins.test.ts
@@ -1,0 +1,20 @@
+import Fastify from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerFastifySessionPlugins } from "@server/registerFastifySessionPlugins.js";
+
+describe("registerFastifySessionPlugins", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("throws when NODE_ENV is production and APP_SECRET_KEY is unset", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("APP_SECRET_KEY", "");
+    const app = Fastify({ logger: false });
+    expect(() => registerFastifySessionPlugins(app)).toThrow(
+      "APP_SECRET_KEY environment variable must be set in production.",
+    );
+    await app.close();
+  });
+});

--- a/tests/registerFastifyStaticAndIndex.test.ts
+++ b/tests/registerFastifyStaticAndIndex.test.ts
@@ -1,0 +1,32 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import Fastify from "fastify";
+import { describe, expect, it } from "vitest";
+import { registerFastifyStaticAndIndex } from "@server/registerFastifyStaticAndIndex.js";
+import { HTTP_STATUS_NOT_FOUND } from "@server/httpStatusCodes.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const clientDistPath = path.join(__dirname, "..", "src", "client", "dist");
+
+describe.skipIf(!fs.existsSync(clientDistPath))("registerFastifyStaticAndIndex", () => {
+  it("GET / returns 404 when cached index html is null", async () => {
+    const app = Fastify({ logger: false });
+    registerFastifyStaticAndIndex(app, null);
+    await app.ready();
+    const res = await app.inject({ method: "GET", url: "/" });
+    expect(res.statusCode).toBe(HTTP_STATUS_NOT_FOUND);
+    await app.close();
+  });
+
+  it("GET / returns 200 html when cached index is provided", async () => {
+    const app = Fastify({ logger: false });
+    registerFastifyStaticAndIndex(app, "<!doctype html><title>unit</title>");
+    await app.ready();
+    const res = await app.inject({ method: "GET", url: "/" });
+    expect(res.statusCode).toBe(200);
+    expect(String(res.headers["content-type"])).toContain("text/html");
+    expect(res.body).toContain("<title>unit</title>");
+    await app.close();
+  });
+});

--- a/tests/serverRoutes.test.ts
+++ b/tests/serverRoutes.test.ts
@@ -11,6 +11,10 @@ describe("server/routes", () => {
   });
 
   it("proxyTargetFromRequestUrl uses replace semantics for the first prefix occurrence", () => {
-    expect(proxyTargetFromRequestUrl("")).toBe("");
+    expect(
+      proxyTargetFromRequestUrl(
+        `${HTTP_API_PATHS.proxyPrefix}/https://example.com${HTTP_API_PATHS.proxyPrefix}/resource`,
+      ),
+    ).toBe(`https://example.com${HTTP_API_PATHS.proxyPrefix}/resource`);
   });
 });

--- a/tests/serverRoutes.test.ts
+++ b/tests/serverRoutes.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { HTTP_API_PATHS, proxyTargetFromRequestUrl } from "@server/routes";
+
+describe("server/routes", () => {
+  it("proxyTargetFromRequestUrl strips the proxy mount prefix", () => {
+    expect(
+      proxyTargetFromRequestUrl(
+        `${HTTP_API_PATHS.proxyPrefix}/https://api.themoviedb.org/3/search/movie?q=1`,
+      ),
+    ).toBe("https://api.themoviedb.org/3/search/movie?q=1");
+  });
+
+  it("proxyTargetFromRequestUrl uses replace semantics for the first prefix occurrence", () => {
+    expect(proxyTargetFromRequestUrl("")).toBe("");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "paths": {
       "@server/*": ["./src/server/*"],
-      "@/*": ["./src/client/src/*"],
-      "@devHttpApiPrefix": ["./src/devHttpApiPrefix.ts"]
+      "@/*": ["./src/client/src/*"]
     },
     "target": "ES2022",
     "module": "NodeNext",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "src/client/src"),
       "@server": path.resolve(__dirname, "src/server"),
-      "@devHttpApiPrefix": path.resolve(__dirname, "src/devHttpApiPrefix.ts"),
     },
   },
   root: "src/client",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "src/client/src"),
       "@server": path.resolve(__dirname, "src/server"),
-      "@devHttpApiPrefix": path.resolve(__dirname, "src/devHttpApiPrefix.ts"),
     },
   },
   test: {


### PR DESCRIPTION
…andler

refactor(createServer): modularize server setup into separate registration functions
feat(fastifyHttpBridge): create FastifyHttpBinder for handling request context
feat(routes): add HTTP_API_PATHS and proxyTargetFromRequestUrl for route management
test(proxy): add tests for proxy handler and URL validation
test(createServer): add tests for server creation and error handling
test(registerFastifySessionPlugins): add tests for session plugin registration
test(registerFastifyStaticAndIndex): add tests for static file serving and index HTML