### PR TITLE
fix: listen on .right-panel scroll container for desktop pagination

### DIFF
--- a/src/client/src/hooks/useLetterboxdList.ts
+++ b/src/client/src/hooks/useLetterboxdList.ts
@@ -74,6 +74,16 @@ function runWithConcurrency(tasks: (() => Promise<unknown>)[], limit: number): P
   ) as Promise<unknown> as Promise<void>;
 }
 
+function isScrollNearBottom(target: EventTarget): boolean {
+  if (target === globalThis) {
+    return (
+      globalThis.innerHeight + globalThis.scrollY + 100 >= document.documentElement.scrollHeight
+    );
+  }
+  const el = target as HTMLElement;
+  return el.scrollTop + el.clientHeight + 100 >= el.scrollHeight;
+}
+
 interface LoadData {
   listUrl?: string;
   country?: string;
@@ -110,6 +120,46 @@ export function useLetterboxdList(
     >
   >(new Map());
   const noPosterReportTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const ensureScrollListener = useCallback(function ensureScrollListener(): void {
+    if (scrollListenerRef.current) return;
+
+    const handleScroll = (e: Event): void => {
+      if (allPagesLoadedRef.current) {
+        const fn = scrollListenerRef.current;
+        if (fn) {
+          for (const c of scrollContainersRef.current) {
+            c.removeEventListener("scroll", fn);
+          }
+        }
+        scrollListenerRef.current = null;
+        scrollContainersRef.current = [];
+        return;
+      }
+      if (isLoadingRef.current) return;
+      if (!isScrollNearBottom(e.currentTarget as EventTarget)) return;
+
+      const d = dataRef.current;
+      if (!d) return;
+      isLoadingRef.current = true;
+      toggleNotice("Loading more pages...");
+      const loadMore =
+        d.listType && d.listType !== "watchlist"
+          ? loadCustomListRef.current
+          : loadWatchlistRef.current;
+      (loadMore || (() => Promise.resolve()))(d).finally(() => {
+        isLoadingRef.current = false;
+      });
+    };
+
+    scrollListenerRef.current = handleScroll;
+    const rightPanel = document.querySelector(".right-panel");
+    scrollContainersRef.current =
+      rightPanel && globalThis.innerWidth >= 1024 ? [rightPanel] : [globalThis];
+    for (const c of scrollContainersRef.current) {
+      c.addEventListener("scroll", handleScroll, { passive: true });
+    }
+  }, []);
 
   const processList = useCallback(
     async (data: LoadData, responseData: LetterboxdListResponse): Promise<void> => {
@@ -266,53 +316,7 @@ export function useLetterboxdList(
         dataRef.current = data;
         if (!allPagesLoadedRef.current) {
           toggleNotice(`Loaded page ${loadedPage} of ${totalPages}...`);
-          if (!scrollListenerRef.current) {
-            const handleScroll = (e: Event) => {
-              if (allPagesLoadedRef.current) {
-                const fn = scrollListenerRef.current;
-                if (fn) {
-                  for (const c of scrollContainersRef.current) {
-                    c.removeEventListener("scroll", fn);
-                  }
-                }
-                scrollListenerRef.current = null;
-                scrollContainersRef.current = [];
-                return;
-              }
-              if (!isLoadingRef.current) {
-                const target = e.currentTarget as EventTarget;
-                let isNearBottom: boolean;
-                if (target === globalThis) {
-                  isNearBottom =
-                    globalThis.innerHeight + globalThis.scrollY + 100 >=
-                    document.documentElement.scrollHeight;
-                } else {
-                  const el = target as HTMLElement;
-                  isNearBottom = el.scrollTop + el.clientHeight + 100 >= el.scrollHeight;
-                }
-                if (isNearBottom) {
-                  const d = dataRef.current;
-                  if (!d) return;
-                  isLoadingRef.current = true;
-                  toggleNotice(`Loading more pages...`);
-                  const loadMore =
-                    d.listType && d.listType !== "watchlist"
-                      ? loadCustomListRef.current
-                      : loadWatchlistRef.current;
-                  (loadMore || (() => Promise.resolve()))(d).finally(() => {
-                    isLoadingRef.current = false;
-                  });
-                }
-              }
-            };
-            scrollListenerRef.current = handleScroll;
-            const rightPanel = document.querySelector(".right-panel");
-            scrollContainersRef.current =
-              rightPanel && globalThis.innerWidth >= 1024 ? [rightPanel] : [globalThis];
-            for (const c of scrollContainersRef.current) {
-              c.addEventListener("scroll", handleScroll, { passive: true });
-            }
-          }
+          ensureScrollListener();
         } else {
           const loadedMessage =
             totalPages === 1
@@ -335,7 +339,7 @@ export function useLetterboxdList(
         }
       }
     },
-    [mergeTile, listMovieTilesRef],
+    [mergeTile, listMovieTilesRef, ensureScrollListener],
   );
 
   const loadWatchlist = useCallback(

--- a/src/client/src/hooks/useLetterboxdList.ts
+++ b/src/client/src/hooks/useLetterboxdList.ts
@@ -91,7 +91,8 @@ export function useLetterboxdList(
 ): (listUrl: string, country: string) => Promise<void> {
   const allPagesLoadedRef = useRef(false);
   const watchlistPageCountRef = useRef(0);
-  const scrollListenerRef = useRef<(() => void) | null>(null);
+  const scrollListenerRef = useRef<((e: Event) => void) | null>(null);
+  const scrollContainersRef = useRef<EventTarget[]>([]);
   const isLoadingRef = useRef(false);
   const isSubmittingListRef = useRef(false);
   const dataRef = useRef<LoadData | null>(null);
@@ -266,34 +267,51 @@ export function useLetterboxdList(
         if (!allPagesLoadedRef.current) {
           toggleNotice(`Loaded page ${loadedPage} of ${totalPages}...`);
           if (!scrollListenerRef.current) {
-            const handleScroll = () => {
+            const handleScroll = (e: Event) => {
               if (allPagesLoadedRef.current) {
-                if (scrollListenerRef.current) {
-                  globalThis.removeEventListener("scroll", scrollListenerRef.current);
-                  scrollListenerRef.current = null;
+                const fn = scrollListenerRef.current;
+                if (fn) {
+                  for (const c of scrollContainersRef.current) {
+                    c.removeEventListener("scroll", fn);
+                  }
                 }
+                scrollListenerRef.current = null;
+                scrollContainersRef.current = [];
                 return;
               }
-              if (
-                !isLoadingRef.current &&
-                globalThis.innerHeight + globalThis.scrollY + 100 >=
-                  document.documentElement.scrollHeight
-              ) {
-                const d = dataRef.current;
-                if (!d) return;
-                isLoadingRef.current = true;
-                toggleNotice(`Loading more pages...`);
-                const loadMore =
-                  d.listType && d.listType !== "watchlist"
-                    ? loadCustomListRef.current
-                    : loadWatchlistRef.current;
-                (loadMore || (() => Promise.resolve()))(d).finally(() => {
-                  isLoadingRef.current = false;
-                });
+              if (!isLoadingRef.current) {
+                const target = e.currentTarget as EventTarget;
+                let isNearBottom: boolean;
+                if (target === globalThis) {
+                  isNearBottom =
+                    globalThis.innerHeight + globalThis.scrollY + 100 >=
+                    document.documentElement.scrollHeight;
+                } else {
+                  const el = target as HTMLElement;
+                  isNearBottom = el.scrollTop + el.clientHeight + 100 >= el.scrollHeight;
+                }
+                if (isNearBottom) {
+                  const d = dataRef.current;
+                  if (!d) return;
+                  isLoadingRef.current = true;
+                  toggleNotice(`Loading more pages...`);
+                  const loadMore =
+                    d.listType && d.listType !== "watchlist"
+                      ? loadCustomListRef.current
+                      : loadWatchlistRef.current;
+                  (loadMore || (() => Promise.resolve()))(d).finally(() => {
+                    isLoadingRef.current = false;
+                  });
+                }
               }
             };
             scrollListenerRef.current = handleScroll;
-            globalThis.addEventListener("scroll", handleScroll, { passive: true });
+            const rightPanel = document.querySelector(".right-panel");
+            scrollContainersRef.current =
+              rightPanel && globalThis.innerWidth >= 1024 ? [rightPanel] : [globalThis];
+            for (const c of scrollContainersRef.current) {
+              c.addEventListener("scroll", handleScroll, { passive: true });
+            }
           }
         } else {
           const loadedMessage =
@@ -453,9 +471,14 @@ export function useLetterboxdList(
   useEffect(() => {
     const batchMap = batchMapRef.current;
     return () => {
-      if (scrollListenerRef.current) {
-        globalThis.removeEventListener("scroll", scrollListenerRef.current);
+      const fn = scrollListenerRef.current;
+      if (fn) {
+        for (const c of scrollContainersRef.current) {
+          c.removeEventListener("scroll", fn);
+        }
       }
+      scrollListenerRef.current = null;
+      scrollContainersRef.current = [];
       batchMap.clear();
       clearTimeout(noPosterReportTimeoutRef.current);
       noPosterReportTimeoutRef.current = undefined;

--- a/tests/e2e/app-test-helpers.ts
+++ b/tests/e2e/app-test-helpers.ts
@@ -62,13 +62,14 @@ export async function mockGeoIpRoute(page: Page): Promise<void> {
  * element and handler body for every scroll listener registered during
  * the page lifecycle. Later, callers query `window.__scrollListenerInfo`
  * to verify which element the pagination handler was attached to.
+ * Callers query `globalThis.__scrollListenerInfo` at test time.
  */
 export async function setupScrollListenerInterceptor(page: Page): Promise<void> {
   await page.addInitScript(() => {
     const original = EventTarget.prototype.addEventListener;
     const info: Array<{ target: string; handlerBody: string }> = [];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).__scrollListenerInfo = info;
+    (globalThis as any).__scrollListenerInfo = info;
 
     EventTarget.prototype.addEventListener = function (
       this: EventTarget,
@@ -91,11 +92,7 @@ export async function setupScrollListenerInterceptor(page: Page): Promise<void> 
 /** Mock the letterboxd-watchlist and search-movie API routes for pagination tests. */
 export async function mockListAndSearchRoutes(page: Page): Promise<void> {
   await page.route("**/api/letterboxd-watchlist", (route) => {
-    const baseList = (
-      letterboxdFixtures[0] as {
-        response: { watchlist: Array<{ title?: string; year?: string | number }> };
-      }
-    ).response.watchlist;
+    const baseList = letterboxdFixtures[0]?.response.watchlist ?? [];
     const watchlist = baseList.map((e) => ({ ...e }));
     return route.fulfill({
       status: 200,

--- a/tests/e2e/app-test-helpers.ts
+++ b/tests/e2e/app-test-helpers.ts
@@ -56,3 +56,71 @@ export async function mockGeoIpRoute(page: Page): Promise<void> {
     }),
   );
 }
+
+/**
+ * Install a scroll addEventListener interceptor that records the target
+ * element and handler body for every scroll listener registered during
+ * the page lifecycle. Later, callers query `window.__scrollListenerInfo`
+ * to verify which element the pagination handler was attached to.
+ */
+export async function setupScrollListenerInterceptor(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const original = EventTarget.prototype.addEventListener;
+    const info: Array<{ target: string; handlerBody: string }> = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__scrollListenerInfo = info;
+
+    EventTarget.prototype.addEventListener = function (
+      this: EventTarget,
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions,
+    ) {
+      if (type === "scroll" && typeof listener === "function") {
+        const targetName =
+          this === globalThis
+            ? "window"
+            : (this as Element).className || (this as Element).tagName || "unknown";
+        info.push({ target: targetName, handlerBody: listener.toString().slice(0, 300) });
+      }
+      return original.call(this, type, listener, options);
+    };
+  });
+}
+
+/** Mock the letterboxd-watchlist and search-movie API routes for pagination tests. */
+export async function mockListAndSearchRoutes(page: Page): Promise<void> {
+  await page.route("**/api/letterboxd-watchlist", (route) => {
+    const baseList = (
+      letterboxdFixtures[0] as {
+        response: { watchlist: Array<{ title?: string; year?: string | number }> };
+      }
+    ).response.watchlist;
+    const watchlist = baseList.map((e) => ({ ...e }));
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        message: "List found",
+        watchlist,
+        lastPage: 1,
+        totalPages: 5,
+        hasMore: true,
+      }),
+    });
+  });
+
+  await page.route("**/api/search-movie", (route) => {
+    const body = route.request().postDataJSON() as SearchMovieBody | null;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        message: "Movie found",
+        movieProviders: [],
+        title: body?.title,
+        year: body?.year,
+      }),
+    });
+  });
+}

--- a/tests/e2e/scroll-pagination.spec.ts
+++ b/tests/e2e/scroll-pagination.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from "@playwright/test";
+import {
+  letterboxdFixtures,
+  mockGeoIpRoute,
+  type SearchMovieBody,
+  waitForGeoReady,
+} from "./app-test-helpers.js";
+
+/** Desktop: verify the pagination scroll handler listens on `.right-panel`
+ *  (the desktop scroll container) rather than `window`.
+ */
+test.describe("Desktop — scroll-listener target", () => {
+  test("pagination scroll handler listens on .right-panel, not window", async ({ page }) => {
+    // Intercept scroll addEventListener to capture the target for the
+    // pagination handler (identified by its body text).
+    await page.addInitScript(() => {
+      const original = EventTarget.prototype.addEventListener;
+      const info: Array<{ target: string; handlerBody: string }> = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__scrollListenerInfo = info;
+
+      EventTarget.prototype.addEventListener = function (
+        this: EventTarget,
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions,
+      ) {
+        if (type === "scroll" && typeof listener === "function") {
+          const targetName =
+            this === globalThis
+              ? "window"
+              : (this as Element).className || (this as Element).tagName || "unknown";
+          info.push({ target: targetName, handlerBody: listener.toString().slice(0, 300) });
+        }
+        return original.call(this, type, listener, options);
+      };
+    });
+
+    await mockGeoIpRoute(page);
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    await page.route("**/api/letterboxd-watchlist", (route) => {
+      const baseList = (
+        letterboxdFixtures[0] as {
+          response: { watchlist: Array<{ title?: string; year?: string | number }> };
+        }
+      ).response.watchlist;
+      const watchlist = baseList.map((e) => ({ ...e }));
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          message: "List found",
+          watchlist,
+          lastPage: 1,
+          totalPages: 5,
+          hasMore: true,
+        }),
+      });
+    });
+    await page.route("**/api/search-movie", (route) => {
+      const body = route.request().postDataJSON() as SearchMovieBody | null;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          message: "Movie found",
+          movieProviders: [],
+          title: body?.title,
+          year: body?.year,
+        }),
+      });
+    });
+
+    await page.goto("/");
+    await waitForGeoReady(page);
+    await page.getByTestId("tab-list").click();
+    await page.getByTestId("list-url").fill("https://letterboxd.com/user/watchlist/");
+    await page.getByTestId("list-submit").click();
+    await expect(page.getByTestId("poster-showcase").getByTestId("tile").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    await page.waitForTimeout(500);
+
+    const info = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).__scrollListenerInfo as Array<{ target: string; handlerBody: string }>,
+    );
+
+    // Find the pagination handler (it references allPagesLoadedRef).
+    const paginationHandler = info.find((h) => h.handlerBody.includes("allPagesLoadedRef"));
+    expect(paginationHandler).toBeDefined();
+
+    // The pagination handler should listen on the panel, not window.
+    // On desktop `.right-panel` is the actual scroll container.
+    // Currently it listens on `window` — this assertion fails.
+    expect(paginationHandler!.target).toBe("right-panel");
+  });
+});
+
+/** Mobile: confirm the pagination handler correctly listens on window. */
+test.describe("Mobile — scroll-listener target", () => {
+  test("pagination scroll handler listens on window (correct for mobile)", async ({ page }) => {
+    await page.addInitScript(() => {
+      const original = EventTarget.prototype.addEventListener;
+      const info: Array<{ target: string; handlerBody: string }> = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__scrollListenerInfo = info;
+
+      EventTarget.prototype.addEventListener = function (
+        this: EventTarget,
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions,
+      ) {
+        if (type === "scroll" && typeof listener === "function") {
+          const targetName =
+            this === globalThis
+              ? "window"
+              : (this as Element).className || (this as Element).tagName || "unknown";
+          info.push({ target: targetName, handlerBody: listener.toString().slice(0, 300) });
+        }
+        return original.call(this, type, listener, options);
+      };
+    });
+
+    await mockGeoIpRoute(page);
+    await page.setViewportSize({ width: 390, height: 800 });
+
+    await page.route("**/api/letterboxd-watchlist", (route) => {
+      const baseList = (
+        letterboxdFixtures[0] as {
+          response: { watchlist: Array<{ title?: string; year?: string | number }> };
+        }
+      ).response.watchlist;
+      const watchlist = baseList.map((e) => ({ ...e }));
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          message: "List found",
+          watchlist,
+          lastPage: 1,
+          totalPages: 5,
+          hasMore: true,
+        }),
+      });
+    });
+    await page.route("**/api/search-movie", (route) => {
+      const body = route.request().postDataJSON() as SearchMovieBody | null;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          message: "Movie found",
+          movieProviders: [],
+          title: body?.title,
+          year: body?.year,
+        }),
+      });
+    });
+
+    await page.goto("/");
+    await waitForGeoReady(page);
+    await page.getByTestId("tab-list").click();
+    await page.getByTestId("list-url").fill("https://letterboxd.com/user/watchlist/");
+    await page.getByTestId("list-submit").click();
+    await expect(page.getByTestId("poster-showcase").getByTestId("tile").first()).toBeVisible({
+      timeout: 30_000,
+    });
+    await page.waitForTimeout(500);
+
+    const info = await page.evaluate(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => (window as any).__scrollListenerInfo as Array<{ target: string; handlerBody: string }>,
+    );
+
+    // On mobile the handler correctly listens on window.
+    const paginationHandler = info.find((h) => h.handlerBody.includes("allPagesLoadedRef"));
+    expect(paginationHandler).toBeDefined();
+    expect(paginationHandler!.target).toBe("window");
+  });
+});

--- a/tests/e2e/scroll-pagination.spec.ts
+++ b/tests/e2e/scroll-pagination.spec.ts
@@ -1,76 +1,33 @@
 import { test, expect } from "@playwright/test";
 import {
-  letterboxdFixtures,
   mockGeoIpRoute,
-  type SearchMovieBody,
+  mockListAndSearchRoutes,
+  setupScrollListenerInterceptor,
   waitForGeoReady,
 } from "./app-test-helpers.js";
 
-/** Desktop: verify the pagination scroll handler listens on `.right-panel`
- *  (the desktop scroll container) rather than `window`.
- */
-test.describe("Desktop — scroll-listener target", () => {
-  test("pagination scroll handler listens on .right-panel, not window", async ({ page }) => {
-    // Intercept scroll addEventListener to capture the target for the
-    // pagination handler (identified by its body text).
-    await page.addInitScript(() => {
-      const original = EventTarget.prototype.addEventListener;
-      const info: Array<{ target: string; handlerBody: string }> = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__scrollListenerInfo = info;
+test.beforeEach(async ({ page }) => {
+  await mockGeoIpRoute(page);
+  await setupScrollListenerInterceptor(page);
+  await mockListAndSearchRoutes(page);
+});
 
-      EventTarget.prototype.addEventListener = function (
-        this: EventTarget,
-        type: string,
-        listener: EventListenerOrEventListenerObject | null,
-        options?: boolean | AddEventListenerOptions,
-      ) {
-        if (type === "scroll" && typeof listener === "function") {
-          const targetName =
-            this === globalThis
-              ? "window"
-              : (this as Element).className || (this as Element).tagName || "unknown";
-          info.push({ target: targetName, handlerBody: listener.toString().slice(0, 300) });
-        }
-        return original.call(this, type, listener, options);
-      };
-    });
+const cases = [
+  {
+    name: "Desktop",
+    viewport: { width: 1280, height: 800 } as const,
+    target: "right-panel",
+  },
+  {
+    name: "Mobile",
+    viewport: { width: 390, height: 800 } as const,
+    target: "window",
+  },
+];
 
-    await mockGeoIpRoute(page);
-    await page.setViewportSize({ width: 1280, height: 800 });
-
-    await page.route("**/api/letterboxd-watchlist", (route) => {
-      const baseList = (
-        letterboxdFixtures[0] as {
-          response: { watchlist: Array<{ title?: string; year?: string | number }> };
-        }
-      ).response.watchlist;
-      const watchlist = baseList.map((e) => ({ ...e }));
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          message: "List found",
-          watchlist,
-          lastPage: 1,
-          totalPages: 5,
-          hasMore: true,
-        }),
-      });
-    });
-    await page.route("**/api/search-movie", (route) => {
-      const body = route.request().postDataJSON() as SearchMovieBody | null;
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          message: "Movie found",
-          movieProviders: [],
-          title: body?.title,
-          year: body?.year,
-        }),
-      });
-    });
+for (const { name, viewport, target } of cases) {
+  test(`${name} — pagination scroll handler listens on ${target}`, async ({ page }) => {
+    await page.setViewportSize(viewport);
 
     await page.goto("/");
     await waitForGeoReady(page);
@@ -87,97 +44,8 @@ test.describe("Desktop — scroll-listener target", () => {
       () => (window as any).__scrollListenerInfo as Array<{ target: string; handlerBody: string }>,
     );
 
-    // Find the pagination handler (it references allPagesLoadedRef).
     const paginationHandler = info.find((h) => h.handlerBody.includes("allPagesLoadedRef"));
     expect(paginationHandler).toBeDefined();
-
-    // The pagination handler should listen on the panel, not window.
-    // On desktop `.right-panel` is the actual scroll container.
-    // Currently it listens on `window` — this assertion fails.
-    expect(paginationHandler!.target).toBe("right-panel");
+    expect(paginationHandler!.target).toBe(target);
   });
-});
-
-/** Mobile: confirm the pagination handler correctly listens on window. */
-test.describe("Mobile — scroll-listener target", () => {
-  test("pagination scroll handler listens on window (correct for mobile)", async ({ page }) => {
-    await page.addInitScript(() => {
-      const original = EventTarget.prototype.addEventListener;
-      const info: Array<{ target: string; handlerBody: string }> = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).__scrollListenerInfo = info;
-
-      EventTarget.prototype.addEventListener = function (
-        this: EventTarget,
-        type: string,
-        listener: EventListenerOrEventListenerObject | null,
-        options?: boolean | AddEventListenerOptions,
-      ) {
-        if (type === "scroll" && typeof listener === "function") {
-          const targetName =
-            this === globalThis
-              ? "window"
-              : (this as Element).className || (this as Element).tagName || "unknown";
-          info.push({ target: targetName, handlerBody: listener.toString().slice(0, 300) });
-        }
-        return original.call(this, type, listener, options);
-      };
-    });
-
-    await mockGeoIpRoute(page);
-    await page.setViewportSize({ width: 390, height: 800 });
-
-    await page.route("**/api/letterboxd-watchlist", (route) => {
-      const baseList = (
-        letterboxdFixtures[0] as {
-          response: { watchlist: Array<{ title?: string; year?: string | number }> };
-        }
-      ).response.watchlist;
-      const watchlist = baseList.map((e) => ({ ...e }));
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          message: "List found",
-          watchlist,
-          lastPage: 1,
-          totalPages: 5,
-          hasMore: true,
-        }),
-      });
-    });
-    await page.route("**/api/search-movie", (route) => {
-      const body = route.request().postDataJSON() as SearchMovieBody | null;
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          message: "Movie found",
-          movieProviders: [],
-          title: body?.title,
-          year: body?.year,
-        }),
-      });
-    });
-
-    await page.goto("/");
-    await waitForGeoReady(page);
-    await page.getByTestId("tab-list").click();
-    await page.getByTestId("list-url").fill("https://letterboxd.com/user/watchlist/");
-    await page.getByTestId("list-submit").click();
-    await expect(page.getByTestId("poster-showcase").getByTestId("tile").first()).toBeVisible({
-      timeout: 30_000,
-    });
-    await page.waitForTimeout(500);
-
-    const info = await page.evaluate(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      () => (window as any).__scrollListenerInfo as Array<{ target: string; handlerBody: string }>,
-    );
-
-    // On mobile the handler correctly listens on window.
-    const paginationHandler = info.find((h) => h.handlerBody.includes("allPagesLoadedRef"));
-    expect(paginationHandler).toBeDefined();
-    expect(paginationHandler!.target).toBe("window");
-  });
-});
+}

--- a/tests/e2e/scroll-pagination.spec.ts
+++ b/tests/e2e/scroll-pagination.spec.ts
@@ -39,13 +39,16 @@ for (const { name, viewport, target } of cases) {
     });
     await page.waitForTimeout(500);
 
-    const info = await page.evaluate(
+    const info = await page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      () => (window as any).__scrollListenerInfo as Array<{ target: string; handlerBody: string }>,
-    );
+      return (globalThis as any).__scrollListenerInfo as Array<{
+        target: string;
+        handlerBody: string;
+      }>;
+    });
 
     const paginationHandler = info.find((h) => h.handlerBody.includes("allPagesLoadedRef"));
-    expect(paginationHandler).toBeDefined();
-    expect(paginationHandler!.target).toBe(target);
+    if (!paginationHandler) throw new Error("Pagination handler not found");
+    expect(paginationHandler.target).toBe(target);
   });
 }


### PR DESCRIPTION
## Summary

Fixes the desktop scroll-pagination bug where scrolling `.right-panel` to the bottom did not trigger the next page load.

**Root cause:** The scroll handler in `useLetterboxdList.ts` was attached only to `window`, but on desktop (viewport ≥1024px) the CSS grid layout makes `.right-panel` the scroll container via `overflow-y: auto`. Scroll events don't bubble, so no event ever reached the handler.

## Changes

### `src/client/src/hooks/useLetterboxdList.ts`
- Added `scrollContainersRef` to track which elements the handler is registered on
- At setup time, detect the correct scroll container: `.right-panel` on desktop (`innerWidth >= 1024`, matching the CSS grid breakpoint), `window` on mobile
- Handler uses `e.currentTarget` to read the right scroll metrics
- Cleanup iterates all containers to remove listeners

### `tests/e2e/scroll-pagination.spec.ts` + `app-test-helpers.ts`
- Rewrote from scroll-to-bottom approach to `addEventListener` interception — directly verifies which element the pagination handler is registered on
- Extracted `setupScrollListenerInterceptor` and `mockListAndSearchRoutes` helpers into `app-test-helpers.ts`
- Parametrized test with a loop, eliminating >90% duplicated lines
- Desktop: asserts target is `.right-panel`
- Mobile: asserts target is `window`
- Removed `test.fail()` marker

## Verification
- `bun run lint` — clean (2 pre-existing warnings)
- `bun run typecheck` — clean
- `bun run test` — 509 passed, 9 skipped (no regressions)
- `npx playwright test tests/e2e/scroll-pagination.spec.ts` — 2 passed