### PR TITLE
UI: dismissable toasts, 2:3 posters, filter cleanup, copy

### DIFF
--- a/src/client/css/global.css
+++ b/src/client/css/global.css
@@ -126,3 +126,78 @@ a {
   border-color: var(--color-accent);
   color: var(--color-accent);
 }
+
+/* Dismissible toast content: message + close button */
+.app-toast-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+}
+
+.app-toast-message {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.app-toast-content--link .app-toast-link {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+}
+
+.app-toast-dismiss {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin: -2px -4px 0 0;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+}
+
+.app-toast-dismiss:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--color-text);
+}
+
+.app-toast-dismiss:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+/* Mobile: keep toasts within the viewport (base width has a 420px floor) */
+@media (max-width: 767px) {
+  .toaster-container {
+    left: 0.75rem !important;
+    right: 0.75rem !important;
+  }
+
+  .toaster-container .app-toast,
+  .app-toast-link {
+    width: auto !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+  }
+
+  .app-toast-content--link {
+    width: 100%;
+  }
+
+  .app-toast-dismiss {
+    width: 32px;
+    height: 32px;
+    margin-top: -4px;
+  }
+}

--- a/src/client/css/poster.css
+++ b/src/client/css/poster.css
@@ -207,6 +207,15 @@
   transform-origin: center center;
   transition: transform 0.36s cubic-bezier(0.2, 0.9, 0.2, 1);
 }
+/* Backdrop poster image only (not provider/external icons): enforce a uniform
+   movie-poster 2:3 shape so tiles are consistently rectangular regardless of
+   the source image's native dimensions. Matches the skeleton's aspect ratio,
+   so there's no reflow when the image loads. */
+.poster-body > img {
+  aspect-ratio: 2 / 3;
+  height: auto;
+  object-fit: cover;
+}
 .poster-info {
   position: absolute;
   bottom: 0;

--- a/src/client/src/__tests__/ToastProvider.test.tsx
+++ b/src/client/src/__tests__/ToastProvider.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, waitFor } from "@testing-library/react";
+import { render, cleanup, waitFor, fireEvent } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import React from "react";
 import { ToastProvider } from "../components/ToastProvider";
@@ -73,17 +73,51 @@ describe("ToastProvider", () => {
 
     impl?.success?.("ok");
     expect(toastSuccess).toHaveBeenCalledWith(
-      "ok",
+      expect.any(Function),
       expect.objectContaining({ className: "app-toast" }),
     );
+    const successRender = toastSuccess.mock.calls[0][0] as (t: {
+      id: string;
+    }) => React.ReactElement;
+    const successMarkup = renderToStaticMarkup(successRender({ id: "s1" }));
+    expect(successMarkup).toContain("ok");
+    expect(successMarkup).toContain('aria-label="Dismiss notification"');
 
     impl?.error?.("bad");
     expect(toastError).toHaveBeenCalledWith(
-      "bad",
+      expect.any(Function),
       expect.objectContaining({
+        duration: Infinity,
         style: expect.objectContaining({ borderColor: "#b91c1c" }),
       }),
     );
+    const errorRender = toastError.mock.calls[0][0] as (t: { id: string }) => React.ReactElement;
+    const errorMarkup = renderToStaticMarkup(errorRender({ id: "e1" }));
+    expect(errorMarkup).toContain("bad");
+    expect(errorMarkup).toContain('aria-label="Dismiss notification"');
+  });
+
+  it("clicking the dismiss button dismisses that specific toast", async () => {
+    await renderToastProvider(<ToastProvider>{"x"}</ToastProvider>);
+    const impl = getToastImpl();
+
+    impl?.error?.("boom");
+    const errorRender = toastError.mock.calls[0][0] as (t: { id: string }) => React.ReactElement;
+
+    const { getByRole } = render(errorRender({ id: "toast-42" }));
+    fireEvent.click(getByRole("button", { name: "Dismiss notification" }));
+    expect(toastDismiss).toHaveBeenCalledWith("toast-42");
+  });
+
+  it("link toast dismiss button dismisses that specific toast", async () => {
+    await renderToastProvider(<ToastProvider>{null}</ToastProvider>);
+    const impl = getToastImpl();
+    messageWithLinkPayload(impl!, { url: "https://example.com/x", text: "Open" });
+    const [renderFn] = toastCustom.mock.calls[0] as [(t: { id: string }) => React.ReactElement];
+
+    const { getByRole } = render(renderFn({ id: "link-7" }));
+    fireEvent.click(getByRole("button", { name: "Dismiss notification" }));
+    expect(toastDismiss).toHaveBeenCalledWith("link-7");
   });
 
   it("loading uses default copy when message is nullish", async () => {
@@ -109,14 +143,15 @@ describe("ToastProvider", () => {
 
     expect(toastCustom).toHaveBeenCalledTimes(1);
     const [renderFn, opts] = toastCustom.mock.calls[0] as [
-      () => React.ReactElement,
+      (t: { id: string }) => React.ReactElement,
       Record<string, unknown>,
     ];
     expect(opts).toMatchObject({ duration: Infinity, position: "top-right" });
 
-    const markup = renderToStaticMarkup(renderFn());
+    const markup = renderToStaticMarkup(renderFn({ id: "l1" }));
     expect(markup).toContain('href="https://example.com/path"');
     expect(markup).toContain(">Open</a>");
+    expect(markup).toContain('aria-label="Dismiss notification"');
   });
 
   it("messageWithLink falls back to toast.success for null, string, and error object", async () => {
@@ -139,8 +174,8 @@ describe("ToastProvider", () => {
     const impl = getToastImpl()!;
     messageWithLinkPayload(impl, { text: "label only" });
     expect(toastCustom).toHaveBeenCalledTimes(1);
-    const [renderFn] = toastCustom.mock.calls[0] as [() => React.ReactElement];
-    const markup = renderToStaticMarkup(renderFn());
+    const [renderFn] = toastCustom.mock.calls[0] as [(t: { id: string }) => React.ReactElement];
+    const markup = renderToStaticMarkup(renderFn({ id: "l2" }));
     expect(markup).toContain('href="#"');
     expect(markup).toContain(">label only</a>");
   });

--- a/src/client/src/__tests__/searchPanelTabIsolation.test.tsx
+++ b/src/client/src/__tests__/searchPanelTabIsolation.test.tsx
@@ -1,16 +1,10 @@
 // @vitest-environment jsdom
-import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createRoot } from "react-dom/client";
 import { act } from "@testing-library/react";
 import { createInitialTabbedTileState, mergeTileStateForTab } from "../utils/movieTiles";
-import {
-  AppStateProvider,
-  selectActiveTileState,
-  useAppState,
-} from "../components/AppStateContext";
+import { AppStateProvider, selectActiveTileState } from "../components/AppStateContext";
 import { LeftPanel } from "../components/LeftPanel";
-import { RightPanel } from "../components/RightPanel";
 import { jsonResponse } from "./jsonResponse";
 
 const COUNTRY_STORAGE_KEY = "letterboxd-justwatch-country";
@@ -93,72 +87,5 @@ describe("search panel tab isolation model", () => {
     expect(container.textContent?.includes("Torrent search")).toBe(false);
 
     localStorage.removeItem(COUNTRY_STORAGE_KEY);
-  });
-
-  it("hides alternative search icon when active tab is list", async () => {
-    function Setup(): React.ReactElement {
-      const { setShowAltSearchButton, setActiveTab } = useAppState();
-      const [phase, setPhase] = React.useState<0 | 1>(0);
-      React.useEffect(() => {
-        if (phase === 0) {
-          setShowAltSearchButton(true);
-          setPhase(1);
-          return;
-        }
-        setActiveTab("list");
-      }, [phase, setActiveTab, setShowAltSearchButton]);
-      return <RightPanel />;
-    }
-
-    const container = document.createElement("div");
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        <AppStateProvider>
-          <Setup />
-        </AppStateProvider>,
-      );
-    });
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    expect(container.querySelector('img[alt="Alternative search"]')).toBeNull();
-  });
-
-  it("shows alternative search icon on list after a list search", async () => {
-    let resolveListLoadComplete: (() => void) | null = null;
-    const listLoadComplete = new Promise<void>((resolve) => {
-      resolveListLoadComplete = resolve;
-    });
-
-    function Setup(): React.ReactElement {
-      const { setActiveTab, loadLetterboxdList } = useAppState();
-      React.useEffect(() => {
-        setActiveTab("list");
-        void loadLetterboxdList("https://letterboxd.com/test-user/watchlist/", "US").finally(() => {
-          resolveListLoadComplete?.();
-        });
-      }, [loadLetterboxdList, setActiveTab]);
-      return <RightPanel />;
-    }
-
-    const container = document.createElement("div");
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        <AppStateProvider>
-          <Setup />
-        </AppStateProvider>,
-      );
-    });
-
-    await act(async () => {
-      await listLoadComplete;
-    });
-
-    expect(container.querySelector('img[alt="Alternative search"]')).not.toBeNull();
   });
 });

--- a/src/client/src/__tests__/showError.test.tsx
+++ b/src/client/src/__tests__/showError.test.tsx
@@ -98,6 +98,6 @@ describe("showBatchErrors", () => {
       { title: "A", year: 1, message: "" },
       { title: "B", year: 2, message: "" },
     ]);
-    expect(errorFn.mock.calls[0][0]).toContain("2 titles encountered errors");
+    expect(errorFn.mock.calls[0][0]).toContain("2 titles didn't load");
   });
 });

--- a/src/client/src/components/RightPanel.tsx
+++ b/src/client/src/components/RightPanel.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo, useCallback } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { motionTransition } from "../animation/timing";
 import { useAppState } from "./AppStateContext";
-import alternativeSearchIcon from "../assets/alternative-search.svg";
 import { getTileProviderNames } from "../utils/movieTiles";
 import type { TileData } from "../utils/movieTiles";
 import { VirtualizedPosterShowcase } from "./VirtualizedPosterShowcase";
@@ -42,22 +41,16 @@ export function RightPanel(): React.ReactElement {
     movieTiles: tiles,
     streamingProviders: providers,
     runAlternativeSearch,
-    showAltSearchButton,
     isAlternativeSearchLoading,
   } = useAppState();
   const reduceMotion = useReducedMotion();
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
-  const [altSearchFilter, setAltSearchFilter] = useState(false);
   const [footerMessage] = useState(() => getRandomMessage());
 
   const toggleFilter = (name: string): void => {
     setActiveFilters((prev) =>
       prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
     );
-  };
-
-  const toggleAltSearchFilter = (): void => {
-    setAltSearchFilter((prev) => !prev);
   };
 
   const [focusedProvider, setFocusedProvider] = useState<string | null>(null);
@@ -73,12 +66,11 @@ export function RightPanel(): React.ReactElement {
     const filterSet = createProviderFilterSet(activeFilters);
     return tileList.filter((tile: TileData) => {
       const names = getTileProviderNames(tile);
-      if (altSearchFilter) return names.length > 0;
       if (!filterSet) return true;
       if (!names.length) return false;
       return tileMatchesProviderFilter(names, filterSet);
     });
-  }, [tileList, activeFilters, altSearchFilter]);
+  }, [tileList, activeFilters]);
 
   const handleAlternativeSearch = useCallback(
     (tileData: TileData): void => {
@@ -150,26 +142,6 @@ export function RightPanel(): React.ReactElement {
             </motion.button>
           );
         })}
-        {showAltSearchButton ? (
-          <motion.button
-            type="button"
-            className={`streaming-provider-icon streaming-provider-icon--alt-search ${
-              altSearchFilter ? "active" : ""
-            }`}
-            data-sp="alternative search"
-            title="Alternative search"
-            aria-pressed={altSearchFilter}
-            onClick={toggleAltSearchFilter}
-            initial={"idle"}
-            animate={altSearchFilter ? "selected" : "idle"}
-            whileHover={reduceMotion ? undefined : { scale: 1.02 }}
-            whileTap={reduceMotion ? undefined : { scale: 0.985 }}
-            variants={{ idle: { scale: 1, y: 0 }, selected: { scale: 1.04, y: -0.8 } }}
-            transition={motionTransition(PROVIDER_FAST_S)}
-          >
-            <img src={alternativeSearchIcon} alt="Alternative search" />
-          </motion.button>
-        ) : null}
       </div>
       <div className="poster-showcase" data-testid="poster-showcase">
         <VirtualizedPosterShowcase
@@ -180,18 +152,18 @@ export function RightPanel(): React.ReactElement {
       <footer>
         <div id="minecraft-text">{footerMessage}</div>
         <p className="foot-notes">
-          This site helps you find where to watch <u>Movies</u>, not TV shows. It checks everything
-          with JustWatch & TMDB & OMDb API to make sure it&apos;s accurate. If it can&apos;t find
-          the movie you want, it won&apos;t suggest random stuff. <br />
-          Please don&apos;t use torrent or piracy sites—unauthorized downloads violate copyright and
-          we can&apos;t recommend them. We get it: some titles aren&apos;t legally available
+          This site helps you find where to watch <u>Movies</u>, not TV shows. It cross-checks
+          JustWatch, TMDB, and OMDb so the results are accurate. If it can&apos;t find the movie you
+          want, it won&apos;t suggest random stuff. <br />
+          Please don&apos;t use torrent or piracy sites. Unauthorized downloads violate copyright,
+          so we can&apos;t recommend them. We get it: some titles aren&apos;t legally available
           anywhere, or only with <u>bad dubbing and no subtitles</u>. Still, stick to legal options
           when you can.
         </p>
         <details className="jackett-details">
           <summary className="jackett-summary">What&apos;s Alternative search?</summary>
           <div className="jackett-body">
-            It uses Jackett API to search for torrents on 1337x, RARBG, etc.
+            It uses the Jackett API to search torrent indexers like 1337x and RARBG.
           </div>
         </details>
       </footer>

--- a/src/client/src/components/ToastProvider.tsx
+++ b/src/client/src/components/ToastProvider.tsx
@@ -5,6 +5,28 @@ import { sanitizeHrefForToast } from "../utils/htmlSafeForToast";
 import { TOAST_DEFAULT_DURATION_MS } from "../animation/timing";
 import { WaitCue } from "./WaitCue";
 
+function DismissButton({ toastId }: { toastId: string }): React.ReactElement {
+  return (
+    <button
+      type="button"
+      className="app-toast-dismiss"
+      aria-label="Dismiss notification"
+      onClick={() => toast.dismiss(toastId)}
+    >
+      ×
+    </button>
+  );
+}
+
+function dismissible(message: React.ReactNode, toastId: string): React.ReactElement {
+  return (
+    <span className="app-toast-content">
+      <span className="app-toast-message">{message}</span>
+      <DismissButton toastId={toastId} />
+    </span>
+  );
+}
+
 const toastStyle = {
   background: "#10161d",
   color: "#d9e8ed",
@@ -24,10 +46,12 @@ const toastOptions = {
 export function ToastProvider({ children }: { children: React.ReactNode }): React.ReactElement {
   useEffect(() => {
     setToastImpl({
-      success: (msg: string) => toast.success(String(msg ?? ""), toastOptions),
+      success: (msg: string) =>
+        toast.success((t) => dismissible(String(msg ?? ""), t.id), toastOptions),
       error: (msg: string) =>
-        toast.error(String(msg ?? ""), {
+        toast.error((t) => dismissible(String(msg ?? ""), t.id), {
           ...toastOptions,
+          duration: Infinity,
           style: { ...toastStyle, borderColor: "#b91c1c" },
           iconTheme: { primary: "#ef4444", secondary: "#10161d" },
         }),
@@ -53,15 +77,18 @@ export function ToastProvider({ children }: { children: React.ReactNode }): Reac
         const url = data.url;
         const text = data.text ?? "";
         toast.custom(
-          () => (
-            <a
-              href={sanitizeHrefForToast(url)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="app-toast-link"
-            >
-              {text}
-            </a>
+          (t) => (
+            <span className="app-toast-content app-toast-content--link">
+              <a
+                href={sanitizeHrefForToast(url)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="app-toast-link"
+              >
+                {text}
+              </a>
+              <DismissButton toastId={t.id} />
+            </span>
           ),
           { duration: Infinity, position: "top-right", style: toastStyle },
         );

--- a/src/client/src/utils/showError.ts
+++ b/src/client/src/utils/showError.ts
@@ -46,13 +46,12 @@ export const showBatchErrors = (errors: BatchError[] | null | undefined): void =
   const uniqueMessages = [...new Set(errors.map((e) => e.message).filter(Boolean))];
   let batchMessage: string;
   if (uniqueMessages.length === 0) {
-    batchMessage = `${errors.length} titles encountered errors while loading.`;
+    batchMessage = `${errors.length} titles didn't load.`;
   } else if (uniqueMessages.length === 1) {
     batchMessage = `${errors.length} titles: ${uniqueMessages[0]}`;
   } else {
     batchMessage =
-      `${errors.length} titles encountered errors while loading:\n` +
-      uniqueMessages.map((msg) => `- ${msg}`).join("\n");
+      `${errors.length} titles didn't load:\n` + uniqueMessages.map((msg) => `- ${msg}`).join("\n");
   }
   showError(batchMessage);
 };

--- a/src/server/controllers/searchMovie.ts
+++ b/src/server/controllers/searchMovie.ts
@@ -221,7 +221,7 @@ function buildNoStreamingResponse(params: {
   country: string;
 }): Record<string, unknown> {
   return {
-    error: `No streaming services offering this movie on your country (${params.country})\n\nNothing on streaming? Try Alternative search on the film tile.`,
+    error: `Not available on any streaming service in your country (${params.country}). Try Alternative search on the film tile.`,
     title: params.title,
     year: params.year,
     poster: params.poster,

--- a/tests/e2e/list-form.spec.ts
+++ b/tests/e2e/list-form.spec.ts
@@ -143,9 +143,7 @@ test.describe("List form", () => {
     await expect(page.getByTestId("poster-showcase").getByTestId("tile")).toHaveCount(3, {
       timeout: 15000,
     });
-    const groupedToast = page
-      .getByRole("status")
-      .filter({ hasText: /3 titles (encountered errors|:)/ });
+    const groupedToast = page.getByRole("status").filter({ hasText: /3 titles (didn't load|:)/ });
     await expect(groupedToast).toBeVisible({ timeout: 5000 });
     await expect(groupedToast).toHaveCount(1);
   });
@@ -190,7 +188,9 @@ test.describe("List form", () => {
       timeout: 10000,
     });
     await expect(
-      page.getByRole("status").filter({ hasText: /A Ghost Story|No streaming|alternative search/ }),
+      page
+        .getByRole("status")
+        .filter({ hasText: /A Ghost Story|Not available|Alternative search/i }),
     ).toBeVisible({ timeout: 5000 });
   });
 });

--- a/tests/fixtures/api/search-movie.json
+++ b/tests/fixtures/api/search-movie.json
@@ -6,7 +6,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "A Ghost Story",
       "year": 2017,
       "poster": "https://images.justwatch.com/poster/8851402/s592/.jpg"
@@ -19,7 +19,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "The Old Man & the Gun",
       "year": 2018,
       "poster": "https://images.justwatch.com/poster/87980559/s592/.jpg"
@@ -44,7 +44,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Her Private Hell",
       "year": 2026,
       "poster": "https://images.justwatch.com/poster/338500011/s592/.jpg"
@@ -57,7 +57,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Exit 8",
       "year": 2025,
       "poster": "https://images.justwatch.com/poster/341598158/s592/.jpg"
@@ -70,7 +70,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "It's Never Over, Jeff Buckley",
       "year": 2025,
       "poster": "https://images.justwatch.com/poster/333094905/s592/.jpg"
@@ -83,7 +83,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Dinner in America",
       "year": 2020,
       "poster": "https://images.justwatch.com/poster/283786918/s592/.jpg"
@@ -96,7 +96,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Shoplifters",
       "year": 2018,
       "poster": "https://images.justwatch.com/poster/94182642/s592/.jpg"
@@ -109,7 +109,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Lake Mungo",
       "year": 2009,
       "poster": "https://images.justwatch.com/poster/125301487/s592/.jpg"
@@ -122,7 +122,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Mystery Train",
       "year": 1989,
       "poster": "https://images.justwatch.com/poster/179644979/s592/.jpg"
@@ -135,7 +135,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "You'll Never Find Me",
       "year": 2024,
       "poster": "https://images.justwatch.com/poster/327158203/s592/.jpg"
@@ -148,7 +148,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "La Femme Nikita",
       "year": 1990,
       "poster": "https://images.justwatch.com/poster/67815690/s592/.jpg"
@@ -190,7 +190,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Nähtamatu võitlus",
       "year": 2023,
       "poster": "https://images.justwatch.com/poster/312842566/s592/.jpg"
@@ -203,7 +203,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Idiot Box",
       "year": 1997,
       "poster": "https://images.justwatch.com/poster/243499536/s592/.jpg"
@@ -216,7 +216,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Savvusanna sõsarad",
       "year": 2023,
       "poster": "https://images.justwatch.com/poster/307072205/s592/.jpg"
@@ -229,7 +229,7 @@
       "country": "es_UY"
     },
     "response": {
-      "error": "No streaming services offering this movie on your country (UY)\n\nNothing on streaming? Try Alternative search on the film tile.",
+      "error": "Not available on any streaming service in your country (UY). Try Alternative search on the film tile.",
       "title": "Ghost World",
       "year": 2001,
       "poster": "https://images.justwatch.com/poster/176230141/s592/.jpg"

--- a/tests/searchMovie.controller.test.ts
+++ b/tests/searchMovie.controller.test.ts
@@ -253,7 +253,7 @@ describe("searchMovie controller", () => {
     const payload = args.res.jsonMock.mock.calls[0][0] as {
       error?: string;
     };
-    expect(payload.error).toContain("No streaming services");
+    expect(payload.error).toContain("Not available on any streaming service");
   });
 
   it("returns no streaming services when offers exist but none are streamable types", async () => {
@@ -301,7 +301,7 @@ describe("searchMovie controller", () => {
     const payload = args.res.jsonMock.mock.calls[0][0] as {
       error?: string;
     };
-    expect(payload.error).toContain("No streaming services");
+    expect(payload.error).toContain("Not available on any streaming service");
   });
 
   it("returns success with movieProviders on happy path", async () => {


### PR DESCRIPTION
Batch of UI tweaks to the movie tile grid and notifications.

## Changes

**Dismissable notifications** (`feat(toast)`)
- Added a `×` dismiss button to success, error, and link toasts via a shared `DismissButton`/`dismissible` helper that calls `toast.dismiss(t.id)`.
- Error toasts now persist (`duration: Infinity`) since they have an explicit close control.
- Mobile width fix: the base `.app-toast` had a 420px floor that overflowed small phones; toasts now fit the viewport under 767px.

**Uniform 2:3 posters** (`style(poster)`)
- Backdrop image was `height: auto`, so tiles took each source image's native ratio (inconsistent, ~1.42 for some). Scoped `aspect-ratio: 2 / 3` + `object-fit: cover` to `.poster-body > img` (not the provider/external icons) so tiles are uniformly rectangular and match the skeleton, removing the load-time reflow.

**Removed alternative-search filter button** (`refactor(filters)`)
- Dropped the alt-search toggle from the provider filter row plus its now-dead locals. The per-tile alternative-search action is unaffected.
- Removed two obsolete `searchPanelTabIsolation` tests that asserted on the removed icon.

**Humanized copy** (`docs(copy)` + footer in the refactor commit)
- Reworded the batch-error header ("N titles didn't load") and the no-streaming message ("Not available on any streaming service in your country…"), fixing grammar and dropping the rhetorical-question phrasing.
- Refreshed the footer notes (dropped an em dash, smoothed wording).

## Tests
- Added coverage for the dismiss-button click path (error + link toasts) calling `toast.dismiss` with the correct id.
- Updated assertions, the e2e regexes, and the API fixture to match the new copy.
- `bun run lint && typecheck && knip && test` all green (509 passed / 9 skipped).

https://claude.ai/code/session_01PrqveB7VXQFVhnHMsb14pw